### PR TITLE
Upgrade GitHub Actions Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,10 @@ jobs:
   meson-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - uses: BSFishy/meson-build@v1.0.3
         with:
           action: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - uses: BSFishy/meson-build@v1.0.3
+      - run: pip install meson ninja
+      - run: meson setup builddir/
+        env:
+          CC: gcc
+      - run: meson test -C builddir/ -v
+      - uses: actions/upload-artifact@v1
+        if: failure()
         with:
-          action: test
-          directory: build
-          options: --verbose
-          meson-version: 1.2.3
+          name: Linux_Meson_Testlog
+          path: builddir/meson-logs/testlog.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)
-
+![Meson Test](https://github.com/thedavidchu/online_mrc/blob/main/.github/workflows/build.yml/badge.svg)
 # On-Line Miss-Rate Curves
 
 This repository analyzes the performance of on-line miss-rate curve (MRC)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)
-[![Meson Test](https://github.com/thedavidchu/online_mrc/workflows/meson-build/badge.svg)](https://github.com/thedavidchu/online_mrc/actions)
+[![Meson Test](https://github.com/thedavidchu/online_mrc/workflows/build.yml/badge.svg)](https://github.com/thedavidchu/online_mrc/actions)
+
 # On-Line Miss-Rate Curves
 
 This repository analyzes the performance of on-line miss-rate curve (MRC)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)
-![Meson Test](https://github.com/thedavidchu/online_mrc/blob/main/.github/workflows/build.yml/badge.svg)
+[![Meson Test](https://github.com/thedavidchu/online_mrc/blob/main/.github/workflows/build.yml/badge.svg)](https://github.com/thedavidchu/online_mrc/actions)
 # On-Line Miss-Rate Curves
 
 This repository analyzes the performance of on-line miss-rate curve (MRC)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)
-[![Meson Test](https://github.com/thedavidchu/online_mrc/workflows/build.yml/badge.svg)](https://github.com/thedavidchu/online_mrc/actions)
+[![Meson Test](https://github.com/thedavidchu/online_mrc/workflows/meson-build/badge.svg)](https://github.com/thedavidchu/online_mrc/actions)
 
 # On-Line Miss-Rate Curves
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![cpp-linter](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml/badge.svg)](https://github.com/cpp-linter/cpp-linter-action/actions/workflows/cpp-linter.yml)
-[![Meson Test](https://github.com/thedavidchu/online_mrc/blob/main/.github/workflows/build.yml/badge.svg)](https://github.com/thedavidchu/online_mrc/actions)
+[![Meson Test](https://github.com/thedavidchu/online_mrc/workflows/meson-build/badge.svg)](https://github.com/thedavidchu/online_mrc/actions)
 # On-Line Miss-Rate Curves
 
 This repository analyzes the performance of on-line miss-rate curve (MRC)


### PR DESCRIPTION
- Node 16 is deprecated in favour of Node 20
- Upgrade the following packages:
    - [x] actions/checkout@v2 (site: https://github.com/actions/checkout)
    - [x] actions/setup-python@v1 (site: https://github.com/actions/setup-python)
- Remove the following packages as dependencies
    - [x] BSFishy/meson-build@v1.0.3 (site: https://github.com/BSFishy/meson-build)

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Information on using Meson in GitHub Actions CI: https://github.com/mesonbuild/meson/blob/master/docs/markdown/Continuous-Integration.md

Information on adding status badges to README: https://dev.to/robdwaller/how-to-add-a-github-actions-badge-to-your-project-11ci