### PR TITLE
Improve memory efficiency of hash table

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,8 @@ jobs:
       - run: |
           ls /usr/include/boost
           echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
+          BOOST_ROOT=/usr/include/boost/boost
+          echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
       - run: meson setup builddir/
         env:
           CC: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,8 @@ jobs:
       #       packages to '/usr/include', but I can't get Meson to
       #       detect it otherwise!
       - run: sudo chmod a+rwx /usr/include
+      - run: |
+          ls /usr/include
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
@@ -42,6 +44,10 @@ jobs:
             arch: x86
             # NOTE: If a boost version matching all requirements cannot be found,
             # this build step will fail
+      - run: |
+          ls /usr/include
+          ls /usr/include/boost
+          ls /usr/include/boost/boost
       - run: meson setup builddir/
         env:
           CC: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: |
           sudo mkdir /usr/local/include/boost
           ll /usr/local/include
-          sudo chmod o+wx /usr/local/include/boost
+          sudo chmod a+rwx /usr/local/include/boost
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,6 @@ jobs:
       #       /usr/local/include (i.e. the standard path), so I instead
       - run: |
           sudo mkdir /usr/local/include/boost
-          ls /usr/local/include
           sudo chmod a+rwx /usr/local/include/boost
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,9 @@ jobs:
       #       detect it otherwise!
       - run: sudo chmod a+rwx /usr/include
       - run: |
+          echo ---
           ls /usr/include
+          echo ----
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
@@ -45,9 +47,13 @@ jobs:
             # NOTE: If a boost version matching all requirements cannot be found,
             # this build step will fail
       - run: |
+          echo ---
           ls /usr/include
+          echo ----
           ls /usr/include/boost
+          echo -----
           ls /usr/include/boost/boost
+          echo ------
       - run: meson setup builddir/
         env:
           CC: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,9 +22,7 @@ jobs:
       - run: pip install meson ninja
       # NOTE  I couldn't get the Boost installation to download into
       #       /usr/local/include (i.e. the standard path), so I instead
-      - run: |
-        sudo mkdir /usr/local/include
-        # boost_root=${{github.workspace}}
+      - run: sudo mkdir /usr/local/include/boost
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install meson ninja
+      - run: BOOST_ROOT=${{github.workspace}}
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
@@ -31,7 +32,7 @@ jobs:
             # OPTIONAL: Specify a platform version
             platform_version: 22.04
             # OPTIONAL: Specify a custom install location
-            boost_install_dir: /usr/local/include
+            boost_install_dir: ${{github.workspace}}
             # OPTIONAL: Specify a toolset
             toolset: gcc
             # OPTIONAL: Specify an architecture

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
             # OPTIONAL: Specify a platform version
             platform_version: 22.04
             # OPTIONAL: Specify a custom install location
-            boost_install_dir: /home/runner/some_directory
+            boost_install_dir: /usr/local
             # OPTIONAL: Specify a toolset
             toolset: gcc
             # OPTIONAL: Specify an architecture

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,9 +47,11 @@ jobs:
           echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
           BOOST_ROOT=/usr/include/boost/boost
           echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
+      - run: echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
       - run: meson setup builddir/
         env:
           CC: gcc
+          BOOST_ROOT: /usr/include/boost/boost
       - run: meson test -C builddir/ -v
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install meson ninja
+      # HACK  You're not supposed to add non-package-manager controlled
+      #       packages to '/usr/include', but I can't get Meson to
+      #       detect it otherwise!
       - run: sudo chmod a+rwx /usr/include
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       #       /usr/local/include (i.e. the standard path), so I instead
       - run: |
           sudo mkdir /usr/local/include/boost
-          ll /usr/local/include
+          ls /usr/local/include
           sudo chmod a+rwx /usr/local/include/boost
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
           # NOTE  For some reason, the environment variables are not
           #       transferred between runs, so I have to set the
           #       'BOOST_ROOT' for the C++ Boost library manually.
-          BOOST_ROOT: ${{github.workspace}}
+          BOOST_ROOT: ${{github.workspace}}/boost
       - run: meson test -C builddir/ -v
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,9 @@ jobs:
       - run: pip install meson ninja
       # NOTE  I couldn't get the Boost installation to download into
       #       /usr/local/include (i.e. the standard path), so I instead
-      - run: boost_root=${{github.workspace}}
+      - run: |
+        sudo mkdir /usr/local/include
+        # boost_root=${{github.workspace}}
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
@@ -34,7 +36,7 @@ jobs:
             # OPTIONAL: Specify a platform version
             platform_version: 22.04
             # OPTIONAL: Specify a custom install location
-            boost_install_dir: ${{github.workspace}}
+            boost_install_dir: /usr/local/include
             # OPTIONAL: Specify a toolset
             toolset: gcc
             # OPTIONAL: Specify an architecture

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
             # OPTIONAL: Specify a platform version
             platform_version: 22.04
             # OPTIONAL: Specify a custom install location
-            boost_install_dir: /usr/local
+            boost_install_dir: /usr/local/include
             # OPTIONAL: Specify a toolset
             toolset: gcc
             # OPTIONAL: Specify an architecture

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade
-          sudo apt-get -y install libboost-dev
+          sudo apt-get -y install libboost-all-dev
       - run: meson setup builddir/
         env:
           CC: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,12 +42,6 @@ jobs:
             arch: x86
             # NOTE: If a boost version matching all requirements cannot be found,
             # this build step will fail
-      - run: |
-          ls /usr/include/boost
-          echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
-          BOOST_ROOT=/usr/include/boost/boost
-          echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
-      - run: echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
       - run: meson setup builddir/
         env:
           CC: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,11 @@ jobs:
       - run: meson setup builddir/
         env:
           CC: gcc
+      # Get Boost C++ library
+      - run: |
+          sudo apt-get -y update
+          sudo apt-get -y upgrade
+          sudo apt-get -y install libboost-dev
       - run: meson test -C builddir/ -v
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,11 +43,8 @@ jobs:
             # NOTE: If a boost version matching all requirements cannot be found,
             # this build step will fail
       - run: |
-          echo ---
-          echo ----
           ls /usr/include/boost
-          echo -----
-          echo ------
+          echo $BOOST_ROOT $BOOST_INCLUDEDIR $BOOST_LIBRARYDIR
       - run: meson setup builddir/
         env:
           CC: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,8 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install meson ninja
+      # NOTE  I couldn't get the Boost installation to download into
+      #       /usr/local/include (i.e. the standard path), so I instead
       - run: BOOST_ROOT=${{github.workspace}}
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
           # NOTE  For some reason, the environment variables are not
           #       transferred between runs, so I have to set the
           #       'BOOST_ROOT' for the C++ Boost library manually.
-          BOOST_ROOT: ${{github.workspace}}/boost
+          BOOST_ROOT: ${{github.workspace}}/boost/boost
       - run: meson test -C builddir/ -v
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,8 +23,8 @@ jobs:
       # NOTE  I couldn't get the Boost installation to download into
       #       /usr/local/include (i.e. the standard path), so I instead
       - run: |
-          sudo mkdir /usr/local/include/boost
-          sudo chmod a+rwx /usr/local/include/boost
+          sudo chmod a+rwx /usr/local/include
+          PATH=$PATH:/usr/local/include/boost:/usr/local/include
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,10 @@ jobs:
       - run: pip install meson ninja
       # NOTE  I couldn't get the Boost installation to download into
       #       /usr/local/include (i.e. the standard path), so I instead
-      - run: sudo mkdir /usr/local/include/boost
+      - run: |
+        sudo mkdir /usr/local/include/boost
+        ll /usr/local/include
+        sudo chmod o+wx /usr/local/include/boost
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,14 +20,14 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install meson ninja
-      - run: meson setup builddir/
-        env:
-          CC: gcc
       # Get Boost C++ library
       - run: |
           sudo apt-get -y update
           sudo apt-get -y upgrade
           sudo apt-get -y install libboost-dev
+      - run: meson setup builddir/
+        env:
+          CC: gcc
       - run: meson test -C builddir/ -v
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,9 @@ jobs:
       # NOTE  I couldn't get the Boost installation to download into
       #       /usr/local/include (i.e. the standard path), so I instead
       - run: |
-        sudo mkdir /usr/local/include/boost
-        ll /usr/local/include
-        sudo chmod o+wx /usr/local/include/boost
+          sudo mkdir /usr/local/include/boost
+          ll /usr/local/include
+          sudo chmod o+wx /usr/local/include/boost
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,11 +20,24 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install meson ninja
-      # Get Boost C++ library
-      - run: |
-          sudo apt-get -y update
-          sudo apt-get -y upgrade
-          sudo apt-get -y install libboost-all-dev
+      - name: Install boost
+        uses: MarkusJx/install-boost@v2.4.5
+        id: install-boost
+        with:
+            # REQUIRED: Specify the required boost version
+            # A list of supported versions can be found here:
+            # https://github.com/MarkusJx/prebuilt-boost/blob/main/versions-manifest.json
+            boost_version: 1.84.0
+            # OPTIONAL: Specify a platform version
+            platform_version: 22.04
+            # OPTIONAL: Specify a custom install location
+            boost_install_dir: /home/runner/some_directory
+            # OPTIONAL: Specify a toolset
+            toolset: gcc
+            # OPTIONAL: Specify an architecture
+            arch: x86
+            # NOTE: If a boost version matching all requirements cannot be found,
+            # this build step will fail
       - run: meson setup builddir/
         env:
           CC: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,10 +20,6 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install meson ninja
-      # HACK  You're not supposed to add non-package-manager controlled
-      #       packages to '/usr/include', but I can't get Meson to
-      #       detect it otherwise!
-      - run: sudo chmod a+rwx /usr/include
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
@@ -35,7 +31,7 @@ jobs:
             # OPTIONAL: Specify a platform version
             platform_version: 22.04
             # OPTIONAL: Specify a custom install location
-            boost_install_dir: /usr/include
+            boost_install_dir: ${{github.workspace}}
             # OPTIONAL: Specify a toolset
             toolset: gcc
             # OPTIONAL: Specify an architecture
@@ -45,7 +41,10 @@ jobs:
       - run: meson setup builddir/
         env:
           CC: gcc
-          BOOST_ROOT: /usr/include/boost/boost
+          # NOTE  For some reason, the environment variables are not
+          #       transferred between runs, so I have to set the
+          #       'BOOST_ROOT' for the C++ Boost library manually.
+          BOOST_ROOT: ${{github.workspace}}
       - run: meson test -C builddir/ -v
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,11 +20,7 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install meson ninja
-      # NOTE  I couldn't get the Boost installation to download into
-      #       /usr/local/include (i.e. the standard path), so I instead
-      - run: |
-          sudo chmod a+rwx /usr/local/include
-          PATH=$PATH:/usr/local/include/boost:/usr/local/include
+      - run: sudo chmod a+rwx /usr/include
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
@@ -36,7 +32,7 @@ jobs:
             # OPTIONAL: Specify a platform version
             platform_version: 22.04
             # OPTIONAL: Specify a custom install location
-            boost_install_dir: /usr/local/include
+            boost_install_dir: /usr/include
             # OPTIONAL: Specify a toolset
             toolset: gcc
             # OPTIONAL: Specify an architecture

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
       - run: pip install meson ninja
       # NOTE  I couldn't get the Boost installation to download into
       #       /usr/local/include (i.e. the standard path), so I instead
-      - run: BOOST_ROOT=${{github.workspace}}
+      - run: boost_root=${{github.workspace}}
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,10 +24,6 @@ jobs:
       #       packages to '/usr/include', but I can't get Meson to
       #       detect it otherwise!
       - run: sudo chmod a+rwx /usr/include
-      - run: |
-          echo ---
-          ls /usr/include
-          echo ----
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.5
         id: install-boost
@@ -48,11 +44,9 @@ jobs:
             # this build step will fail
       - run: |
           echo ---
-          ls /usr/include
           echo ----
           ls /usr/include/boost
           echo -----
-          ls /usr/include/boost/boost
           echo ------
       - run: meson setup builddir/
         env:

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,11 @@ thread_dep = dependency('threads')
 
 # We require the version to be newer than 1.81.0 so that it includes
 # Boost's 'boost/unordered/unordered_flat_map.hpp' file.
-boost_dep = dependency('boost', version: '>=1.81.0')
+# boost_dep = dependency('boost', version: '>=1.81.0')
+cxx = meson.get_compiler('cpp', native: true)
+boost_dep = [
+    cxx.find_library('boost_unordered'),
+]
 glib_dep = dependency(
     'glib-2.0',
     default_options: [

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,9 @@ cc = meson.get_compiler('c', native: true)
 math_dep = cc.find_library('m', required: false)
 thread_dep = dependency('threads')
 
-boost_dep = dependency('boost')
+# We require the version to be newer than 1.81.0 so that it includes
+# Boost's 'boost/unordered/unordered_flat_map.hpp' file.
+boost_dep = dependency('boost', version: '>=1.81.0')
 glib_dep = dependency(
     'glib-2.0',
     default_options: [

--- a/meson.build
+++ b/meson.build
@@ -31,10 +31,7 @@ thread_dep = dependency('threads')
 # We require the version to be newer than 1.81.0 so that it includes
 # Boost's 'boost/unordered/unordered_flat_map.hpp' file.
 boost_dep = dependency('boost', version: '>=1.81.0')
-# cxx = meson.get_compiler('cpp', native: true)
-# boost_dep = [
-#     cxx.find_library('boost_unordered'),
-# ]
+
 glib_dep = dependency(
     'glib-2.0',
     default_options: [

--- a/meson.build
+++ b/meson.build
@@ -30,11 +30,11 @@ thread_dep = dependency('threads')
 
 # We require the version to be newer than 1.81.0 so that it includes
 # Boost's 'boost/unordered/unordered_flat_map.hpp' file.
-# boost_dep = dependency('boost', version: '>=1.81.0')
-cxx = meson.get_compiler('cpp', native: true)
-boost_dep = [
-    cxx.find_library('boost_unordered'),
-]
+boost_dep = dependency('boost', version: '>=1.81.0')
+# cxx = meson.get_compiler('cpp', native: true)
+# boost_dep = [
+#     cxx.find_library('boost_unordered'),
+# ]
 glib_dep = dependency(
     'glib-2.0',
     default_options: [

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ cc = meson.get_compiler('c', native: true)
 math_dep = cc.find_library('m', required: false)
 thread_dep = dependency('threads')
 
+boost_dep = dependency('boost')
 glib_dep = dependency(
     'glib-2.0',
     default_options: [

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ thread_dep = dependency('threads')
 
 # We require the version to be newer than 1.81.0 so that it includes
 # Boost's 'boost/unordered/unordered_flat_map.hpp' file.
-# boost_dep = dependency('boost', version: '>=1.81.0')
+boost_dep = dependency('boost', version: '>=1.81.0')
 
 glib_dep = dependency(
     'glib-2.0',

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ thread_dep = dependency('threads')
 
 # We require the version to be newer than 1.81.0 so that it includes
 # Boost's 'boost/unordered/unordered_flat_map.hpp' file.
-boost_dep = dependency('boost', version: '>=1.81.0')
+# boost_dep = dependency('boost', version: '>=1.81.0')
 
 glib_dep = dependency(
     'glib-2.0',

--- a/src/analysis/cardinality/cardinality_analyzer.c
+++ b/src/analysis/cardinality/cardinality_analyzer.c
@@ -100,7 +100,7 @@ test_cardinality_estimate_accuracy(char const *const fpath,
     for (size_t i = 0; i < artificial_trace_length; ++i) {
         enum PutUniqueStatus s = LOOKUP_PUTUNIQUE_ERROR;
         uint64_t const x = f_next(data);
-        s = HashTable__put_unique(&ht, x, 0);
+        s = HashTable__put(&ht, x, 0);
         EvictingHashTable__try_put(&eht, x, 0);
         if (s == LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE &&
             FixedSizeShardsSampler__sample(&fs, x)) {

--- a/src/analysis/cardinality/cardinality_analyzer.c
+++ b/src/analysis/cardinality/cardinality_analyzer.c
@@ -15,6 +15,7 @@
 #include "lookup/evicting_hash_table.h"
 #include "lookup/hash_table.h"
 #include "lookup/lookup.h"
+#include "olken/olken.h"
 #include "random/uniform_random.h"
 #include "random/zipfian_random.h"
 #include "shards/fixed_rate_shards.h"
@@ -112,7 +113,7 @@ test_cardinality_estimate_accuracy(char const *const fpath,
         size_t eht_size =
             EvictingHashTable__estimate_scale_factor(&eht) * eht.num_inserted;
         size_t fs_size = FixedSizeShardsSampler__estimate_cardinality(&fs);
-        size_t fr_size = fr.scale * HashTable__get_size(&fr.olken.hash_table);
+        size_t fr_size = fr.scale * Olken__get_cardinality(&fr.olken);
         estimates[num_tests * i + 0] = ht_size;
         estimates[num_tests * i + 1] = eht_size;
         estimates[num_tests * i + 2] = fs_size;

--- a/src/analysis/interval/interval_olken.c
+++ b/src/analysis/interval/interval_olken.c
@@ -7,7 +7,6 @@
 #include "interval/interval_olken.h"
 #include "interval_statistics/interval_statistics.h"
 #include "logger/logger.h"
-#include "lookup/hash_table.h"
 #include "lookup/lookup.h"
 #include "olken/olken.h"
 
@@ -50,7 +49,7 @@ IntervalOlken__access_item(struct IntervalOlken *me, EntryType const entry)
         return false;
     }
 
-    struct LookupReturn found = HashTable__lookup(&me->olken.hash_table, entry);
+    struct LookupReturn found = Olken__lookup(&me->olken, entry);
     if (found.success) {
         uint64_t rt = me->olken.current_time_stamp - found.timestamp - 1;
         uint64_t rd = Olken__update_stack(&me->olken, entry, found.timestamp);

--- a/src/analysis/mrc/deprecated_generate_mrc.c
+++ b/src/analysis/mrc/deprecated_generate_mrc.c
@@ -224,7 +224,7 @@ parse_positive_double(char const *const str)
 static void
 print_command_line_arguments(struct CommandLineArguments const *args)
 {
-    fprintf(stderr,
+    fprintf(stdout,
             "CommandLineArguments(executable='%s', input_path='%s', "
             "algorithm='%s', output_path='%s', shards_ratio='%g', "
             "artifical_trace_length='%zu', oracle_path='%s', "

--- a/src/analysis/mrc/deprecated_generate_mrc.c
+++ b/src/analysis/mrc/deprecated_generate_mrc.c
@@ -245,7 +245,7 @@ static void
 print_trace_summary(struct CommandLineArguments const *args,
                     struct Trace const *const trace)
 {
-    fprintf(stderr,
+    fprintf(stdout,
             "Trace(source='%s', format='%s', length=%zu)\n",
             args->input_path,
             TRACE_FORMAT_STRINGS[args->trace_format],

--- a/src/lib/lookup/boost_hash_table.cpp
+++ b/src/lib/lookup/boost_hash_table.cpp
@@ -1,0 +1,92 @@
+#include <boost/unordered/unordered_flat_map.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <stdio.h> // This is for FILE so that it matches the header.
+
+#include "lookup/boost_hash_table.h"
+#include "lookup/lookup.h"
+#include "types/key_type.h"
+#include "types/value_type.h"
+
+struct BoostHashTable {
+    boost::unordered::unordered_flat_map<std::uint64_t, std::uint64_t>
+        hash_table;
+};
+
+struct BoostHashTable *
+BoostHashTable__new(void)
+{
+    std::unique_ptr<struct BoostHashTable> me =
+        std::make_unique<struct BoostHashTable>();
+    std::cout << me.get() << std::endl;
+    struct BoostHashTable *raw_ptr = me.release();
+    std::cout << raw_ptr << std::endl;
+    return raw_ptr;
+}
+
+void
+BoostHashTable__free(struct BoostHashTable *const me)
+{
+    std::unique_ptr<struct BoostHashTable> ptr{me};
+}
+
+struct LookupReturn
+BoostHashTable__lookup(struct BoostHashTable const *const me, KeyType const key)
+{
+    if (me == NULL || !me->hash_table.contains(key)) {
+        return {false, 0};
+    }
+    return {true, me->hash_table.at(key)};
+}
+
+enum PutUniqueStatus
+BoostHashTable__put(struct BoostHashTable *const me,
+                    KeyType const key,
+                    ValueType const value)
+{
+    if (me == NULL) {
+        return LOOKUP_PUTUNIQUE_ERROR;
+    }
+    if (!me->hash_table.contains(key)) {
+        me->hash_table[key] = value;
+        return LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE;
+    }
+    me->hash_table[key] = value;
+    return LOOKUP_PUTUNIQUE_REPLACE_VALUE;
+}
+
+struct LookupReturn
+BoostHashTable__remove(struct BoostHashTable *const me, KeyType const key)
+{
+    if (me == NULL || !me->hash_table.contains(key)) {
+        return {false, 0};
+    }
+    ValueType value = me->hash_table.at(key);
+    me->hash_table.erase(key);
+    return {true, value};
+}
+
+bool
+BoostHashTable__write(struct BoostHashTable const *const me,
+                      FILE *const stream,
+                      bool const newline)
+{
+    if (me == NULL || stream == NULL)
+        return false;
+    fprintf(stream, "{");
+    for (auto [key, value] : me->hash_table) {
+        // NOTE We could remove the trailing comma if we keep track of
+        //      how many items we are printing versus how many we have
+        //      already printed. When we see the last item, then we do
+        //      not print the trailing comma. Alternatively, we could
+        //      print the first item (if it exists) without the trailing
+        //      comma and then print all other items with a leading
+        //      comma. I don't feel like doing these things though.
+        fprintf(stream, "%" PRIu64 ": %" PRIu64 ", ", key, value);
+    }
+    fprintf(stream, "}%s", newline ? "\n" : "");
+    return true;
+}

--- a/src/lib/lookup/boost_hash_table.cpp
+++ b/src/lib/lookup/boost_hash_table.cpp
@@ -101,3 +101,9 @@ BoostHashTable__write(struct BoostHashTable const *const me,
     fprintf(stream, "}%s", newline ? "\n" : "");
     return true;
 }
+
+size_t
+BoostHashTable__get_size(struct BoostHashTable const *const me)
+{
+    return me->private_->hash_table.size();
+}

--- a/src/lib/lookup/evicting_hash_table.c
+++ b/src/lib/lookup/evicting_hash_table.c
@@ -103,9 +103,9 @@ EvictingHashTable__lookup(struct EvictingHashTable *me, KeyType key)
 }
 
 struct SampledPutReturn
-EvictingHashTable__put_unique(struct EvictingHashTable *me,
-                              KeyType key,
-                              ValueType value)
+EvictingHashTable__put(struct EvictingHashTable *me,
+                       KeyType key,
+                       ValueType value)
 {
     if (me == NULL || me->data == NULL || me->length == 0)
         return (struct SampledPutReturn){.status = SAMPLED_NOTFOUND};

--- a/src/lib/lookup/hash_table.c
+++ b/src/lib/lookup/hash_table.c
@@ -60,9 +60,9 @@ HashTable__lookup(struct HashTable const *const me, EntryType const key)
 
 /// @return Returns whether we inserted, replaced, or errored.
 enum PutUniqueStatus
-HashTable__put_unique(struct HashTable *const me,
-                      EntryType const key,
-                      TimeStampType const value)
+HashTable__put(struct HashTable *const me,
+               EntryType const key,
+               TimeStampType const value)
 {
 
     if (me == NULL || me->hash_table == NULL)

--- a/src/lib/lookup/hash_table.c
+++ b/src/lib/lookup/hash_table.c
@@ -20,7 +20,7 @@ gboolean_to_bool(const gboolean b)
 }
 
 bool
-HashTable__init(struct HashTable *me)
+HashTable__init(struct HashTable *const me)
 {
     if (me == NULL)
         return false;
@@ -43,7 +43,7 @@ HashTable__get_size(struct HashTable const *const me)
 }
 
 struct LookupReturn
-HashTable__lookup(struct HashTable *me, EntryType key)
+HashTable__lookup(struct HashTable const *const me, EntryType const key)
 {
     if (me == NULL || me->hash_table == NULL)
         return (struct LookupReturn){.success = false, .timestamp = 0};
@@ -60,7 +60,9 @@ HashTable__lookup(struct HashTable *me, EntryType key)
 
 /// @return Returns whether we inserted, replaced, or errored.
 enum PutUniqueStatus
-HashTable__put_unique(struct HashTable *me, EntryType key, TimeStampType value)
+HashTable__put_unique(struct HashTable *const me,
+                      EntryType const key,
+                      TimeStampType const value)
 {
 
     if (me == NULL || me->hash_table == NULL)
@@ -91,7 +93,7 @@ HashTable__remove(struct HashTable *const me, EntryType const key)
 }
 
 static void
-write_ghashtable_as_json(FILE *stream,
+write_ghashtable_as_json(FILE *const stream,
                          GHashTable *const hash_table,
                          bool const new_line)
 {
@@ -125,7 +127,7 @@ write_ghashtable_as_json(FILE *stream,
 }
 
 void
-HashTable__write_as_json(FILE *stream, struct HashTable const *const me)
+HashTable__write_as_json(FILE *const stream, struct HashTable const *const me)
 {
     if (stream == NULL) {
         LOGGER_WARN("stream == NULL");
@@ -145,7 +147,7 @@ HashTable__write_as_json(FILE *stream, struct HashTable const *const me)
 }
 
 void
-HashTable__destroy(struct HashTable *me)
+HashTable__destroy(struct HashTable *const me)
 {
     if (me == NULL || me->hash_table == NULL)
         return;

--- a/src/lib/lookup/include/lookup/boost_hash_table.h
+++ b/src/lib/lookup/include/lookup/boost_hash_table.h
@@ -1,0 +1,38 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "lookup/lookup.h"
+#include "types/key_type.h"
+#include "types/value_type.h"
+
+struct BoostHashTable *
+BoostHashTable__new(void);
+
+void
+BoostHashTable__free(struct BoostHashTable *const me);
+
+struct LookupReturn
+BoostHashTable__lookup(struct BoostHashTable const *const me,
+                       KeyType const key);
+
+enum PutUniqueStatus
+BoostHashTable__put(struct BoostHashTable *const me,
+                    KeyType const key,
+                    ValueType const value);
+
+struct LookupReturn
+BoostHashTable__remove(struct BoostHashTable *const me, KeyType const key);
+
+bool
+BoostHashTable__write(struct BoostHashTable const *const me,
+                      FILE *const stream,
+                      bool const newline);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/lib/lookup/include/lookup/boost_hash_table.h
+++ b/src/lib/lookup/include/lookup/boost_hash_table.h
@@ -10,11 +10,19 @@ extern "C" {
 #include "types/key_type.h"
 #include "types/value_type.h"
 
-struct BoostHashTable *
-BoostHashTable__new(void);
+struct BoostHashTablePrivate;
+
+struct BoostHashTable {
+    // NOTE I am uninspired and named the private member 'private'. This
+    //      is a keyword in C++, so I need to add the trailing underscore.
+    struct BoostHashTablePrivate *private_;
+};
+
+bool
+BoostHashTable__init(struct BoostHashTable *const me);
 
 void
-BoostHashTable__free(struct BoostHashTable *const me);
+BoostHashTable__destroy(struct BoostHashTable *const me);
 
 struct LookupReturn
 BoostHashTable__lookup(struct BoostHashTable const *const me,

--- a/src/lib/lookup/include/lookup/boost_hash_table.h
+++ b/src/lib/lookup/include/lookup/boost_hash_table.h
@@ -41,6 +41,9 @@ BoostHashTable__write(struct BoostHashTable const *const me,
                       FILE *const stream,
                       bool const newline);
 
+size_t
+BoostHashTable__get_size(struct BoostHashTable const *const me);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/lookup/include/lookup/evicting_hash_table.h
+++ b/src/lib/lookup/include/lookup/evicting_hash_table.h
@@ -69,9 +69,9 @@ struct SampledLookupReturn
 EvictingHashTable__lookup(struct EvictingHashTable *me, KeyType key);
 
 struct SampledPutReturn
-EvictingHashTable__put_unique(struct EvictingHashTable *me,
-                              KeyType key,
-                              ValueType value);
+EvictingHashTable__put(struct EvictingHashTable *me,
+                       KeyType key,
+                       ValueType value);
 
 /// @note   If we know the globally maximum threshold, then we can
 ///         immediately discard any element that is greater than this.

--- a/src/lib/lookup/include/lookup/hash_table.h
+++ b/src/lib/lookup/include/lookup/hash_table.h
@@ -14,22 +14,24 @@ struct HashTable {
 };
 
 bool
-HashTable__init(struct HashTable *me);
+HashTable__init(struct HashTable *const me);
 
 size_t
 HashTable__get_size(struct HashTable const *const me);
 
 struct LookupReturn
-HashTable__lookup(struct HashTable *me, EntryType key);
+HashTable__lookup(struct HashTable const *const me, EntryType const key);
 
 enum PutUniqueStatus
-HashTable__put_unique(struct HashTable *me, EntryType key, TimeStampType value);
+HashTable__put_unique(struct HashTable *const me,
+                      EntryType const key,
+                      TimeStampType const value);
 
 struct LookupReturn
 HashTable__remove(struct HashTable *const me, EntryType const key);
 
 void
-HashTable__write_as_json(FILE *stream, struct HashTable const *const me);
+HashTable__write_as_json(FILE *const stream, struct HashTable const *const me);
 
 void
-HashTable__destroy(struct HashTable *me);
+HashTable__destroy(struct HashTable *const me);

--- a/src/lib/lookup/include/lookup/hash_table.h
+++ b/src/lib/lookup/include/lookup/hash_table.h
@@ -23,9 +23,9 @@ struct LookupReturn
 HashTable__lookup(struct HashTable const *const me, EntryType const key);
 
 enum PutUniqueStatus
-HashTable__put_unique(struct HashTable *const me,
-                      EntryType const key,
-                      TimeStampType const value);
+HashTable__put(struct HashTable *const me,
+               EntryType const key,
+               TimeStampType const value);
 
 struct LookupReturn
 HashTable__remove(struct HashTable *const me, EntryType const key);

--- a/src/lib/lookup/include/lookup/k_hash_table.h
+++ b/src/lib/lookup/include/lookup/k_hash_table.h
@@ -1,19 +1,24 @@
+#pragma once
+
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
-#include "khash.h"
 #include "lookup/lookup.h"
 #include "types/entry_type.h"
 #include "types/time_stamp_type.h"
 
-KHASH_MAP_INIT_INT64(64, uint64_t)
+// HACK This is the post-macro name of the khash_t(64). This is simply
+//      to avoid dumping the namespace of 'khash.h' into all downstream
+//      headers. In theory, this is a pointer anyways, so maybe I can
+//      just have a 'void *'. Who knows?
+struct kh_64_s;
 
 /// @brief  This implemenents a hash table with key and values of type
 ///         uint64_t. It uses the klib library backend.
 struct KHashTable {
-    khash_t(64) * hash_table;
+    struct kh_64_s *hash_table;
 };
 
 bool

--- a/src/lib/lookup/include/lookup/k_hash_table.h
+++ b/src/lib/lookup/include/lookup/k_hash_table.h
@@ -32,9 +32,9 @@ KHashTable__lookup(struct KHashTable const *const me, EntryType key);
 
 /// @return Returns whether we inserted, replaced, or errored.
 enum PutUniqueStatus
-KHashTable__put_unique(struct KHashTable *const me,
-                       EntryType const key,
-                       TimeStampType const value);
+KHashTable__put(struct KHashTable *const me,
+                EntryType const key,
+                TimeStampType const value);
 
 struct LookupReturn
 KHashTable__remove(struct KHashTable *const me, EntryType const key);

--- a/src/lib/lookup/include/lookup/k_hash_table.h
+++ b/src/lib/lookup/include/lookup/k_hash_table.h
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "khash.h"
+#include "lookup/lookup.h"
+#include "types/entry_type.h"
+#include "types/time_stamp_type.h"
+
+KHASH_MAP_INIT_INT64(64, uint64_t)
+
+/// @brief  This implemenents a hash table with key and values of type
+///         uint64_t. It uses the klib library backend.
+struct KHashTable {
+    khash_t(64) * hash_table;
+};
+
+bool
+KHashTable__init(struct KHashTable *me);
+
+size_t
+KHashTable__get_size(struct KHashTable const *const me);
+
+struct LookupReturn
+KHashTable__lookup(struct KHashTable *me, EntryType key);
+
+/// @return Returns whether we inserted, replaced, or errored.
+enum PutUniqueStatus
+KHashTable__put_unique(struct KHashTable *me,
+                       EntryType key,
+                       TimeStampType value);
+
+struct LookupReturn
+KHashTable__remove(struct KHashTable *const me, EntryType const key);
+
+bool
+KHashTable__write(struct KHashTable const *const me,
+                  FILE *const stream,
+                  bool const newline);
+
+void
+KHashTable__destroy(struct KHashTable *me);

--- a/src/lib/lookup/include/lookup/k_hash_table.h
+++ b/src/lib/lookup/include/lookup/k_hash_table.h
@@ -28,13 +28,13 @@ size_t
 KHashTable__get_size(struct KHashTable const *const me);
 
 struct LookupReturn
-KHashTable__lookup(struct KHashTable *me, EntryType key);
+KHashTable__lookup(struct KHashTable const *const me, EntryType key);
 
 /// @return Returns whether we inserted, replaced, or errored.
 enum PutUniqueStatus
-KHashTable__put_unique(struct KHashTable *me,
-                       EntryType key,
-                       TimeStampType value);
+KHashTable__put_unique(struct KHashTable *const me,
+                       EntryType const key,
+                       TimeStampType const value);
 
 struct LookupReturn
 KHashTable__remove(struct KHashTable *const me, EntryType const key);
@@ -45,4 +45,4 @@ KHashTable__write(struct KHashTable const *const me,
                   bool const newline);
 
 void
-KHashTable__destroy(struct KHashTable *me);
+KHashTable__destroy(struct KHashTable *const me);

--- a/src/lib/lookup/include/lookup/k_hash_table.h
+++ b/src/lib/lookup/include/lookup/k_hash_table.h
@@ -22,7 +22,7 @@ struct KHashTable {
 };
 
 bool
-KHashTable__init(struct KHashTable *me);
+KHashTable__init(struct KHashTable *const me);
 
 size_t
 KHashTable__get_size(struct KHashTable const *const me);

--- a/src/lib/lookup/include/lookup/parallel_hash_table.h
+++ b/src/lib/lookup/include/lookup/parallel_hash_table.h
@@ -17,14 +17,14 @@ bool
 ParallelHashTable__init(struct ParallelHashTable *me, size_t num_buckets);
 
 bool
-ParallelHashTable__put_unique(struct ParallelHashTable *me,
-                          EntryType entry,
-                          TimeStampType timestamp);
+ParallelHashTable__put(struct ParallelHashTable *me,
+                       EntryType entry,
+                       TimeStampType timestamp);
 
 bool
-ParallelHashTable__put_unique(struct ParallelHashTable *me,
-                          EntryType entry,
-                          TimeStampType new_timestamp);
+ParallelHashTable__put(struct ParallelHashTable *me,
+                       EntryType entry,
+                       TimeStampType new_timestamp);
 
 struct LookupReturn
 ParallelHashTable__lookup(struct ParallelHashTable *me, EntryType);

--- a/src/lib/lookup/include/lookup/parallel_list.h
+++ b/src/lib/lookup/include/lookup/parallel_list.h
@@ -27,7 +27,7 @@ struct ParallelListNode {
  *  @note   Splay the input key to the front of the list.
  */
 bool
-ParallelList__put_unique(struct ParallelList *me,
+ParallelList__put(struct ParallelList *me,
                   EntryType entry,
                   TimeStampType timestamp);
 

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -7,17 +7,16 @@
 #include <stdio.h>
 
 #include "khash.h"
+#include "lookup/k_hash_table.h"
 #include "lookup/lookup.h"
 #include "types/entry_type.h"
 #include "types/time_stamp_type.h"
 
+// NOTE If I were to put this in the header, then I would be dumping
+//      a whole whack of unwanted symbols into the header namespace.
+//      I did have to do some sketchy stuff, such as directly using the
+//      post-macro names of structures for the proper forward declaration.
 KHASH_MAP_INIT_INT64(64, uint64_t)
-
-/// @brief  This implemenents a hash table with key and values of type
-///         uint64_t. It uses the klib library backend.
-struct KHashTable {
-    khash_t(64) * hash_table;
-};
 
 bool
 KHashTable__init(struct KHashTable *me)

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -95,7 +95,7 @@ KHashTable__write(struct KHashTable const *const me,
                   FILE *const stream,
                   bool const newline)
 {
-    if (me == NULL || me->hash_table == NULL)
+    if (me == NULL || me->hash_table == NULL || stream == NULL)
         return false;
     fprintf(stream, "{");
     for (khiter_t k = kh_begin(me->hash_table); k != kh_end(me->hash_table);

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -42,6 +42,9 @@ KHashTable__lookup(struct KHashTable const *const me, EntryType key)
         return (struct LookupReturn){.success = false, .timestamp = 0};
     khiter_t k = kh_get(64, me->hash_table, key);
     bool found = (k != kh_end(me->hash_table));
+    if (!found) {
+        return (struct LookupReturn){.success = found, .timestamp = 0};
+    }
     uint64_t value = kh_value(me->hash_table, k);
     return (struct LookupReturn){.success = found, .timestamp = value};
 }

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 
 #include "khash.h"
-#include "logger/logger.h"
 #include "lookup/lookup.h"
 #include "types/entry_type.h"
 #include "types/time_stamp_type.h"

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -36,7 +36,7 @@ KHashTable__get_size(struct KHashTable const *const me)
 }
 
 struct LookupReturn
-KHashTable__lookup(struct KHashTable *me, EntryType key)
+KHashTable__lookup(struct KHashTable const *const me, EntryType key)
 {
     if (me == NULL || me->hash_table == NULL)
         return (struct LookupReturn){.success = false, .timestamp = 0};
@@ -48,9 +48,9 @@ KHashTable__lookup(struct KHashTable *me, EntryType key)
 
 /// @return Returns whether we inserted, replaced, or errored.
 enum PutUniqueStatus
-KHashTable__put_unique(struct KHashTable *me,
-                       EntryType key,
-                       TimeStampType value)
+KHashTable__put_unique(struct KHashTable *const me,
+                       EntryType const key,
+                       TimeStampType const value)
 {
 
     if (me == NULL || me->hash_table == NULL)
@@ -116,7 +116,7 @@ KHashTable__write(struct KHashTable const *const me,
 }
 
 void
-KHashTable__destroy(struct KHashTable *me)
+KHashTable__destroy(struct KHashTable *const me)
 {
     if (me == NULL || me->hash_table == NULL)
         return;

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -1,0 +1,127 @@
+/** Use the khash.h file to create a hash table with keys and values of
+ *  type uint64_t. */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "khash.h"
+#include "logger/logger.h"
+#include "lookup/lookup.h"
+#include "types/entry_type.h"
+#include "types/time_stamp_type.h"
+
+KHASH_MAP_INIT_INT64(64, uint64_t)
+
+/// @brief  This implemenents a hash table with key and values of type
+///         uint64_t. It uses the klib library backend.
+struct KHashTable {
+    khash_t(64) * hash_table;
+};
+
+bool
+KHashTable__init(struct KHashTable *me)
+{
+    if (me == NULL)
+        return false;
+    me->hash_table = kh_init(64);
+    if (me->hash_table == NULL)
+        return false;
+    return true;
+}
+
+size_t
+KHashTable__get_size(struct KHashTable const *const me)
+{
+    return kh_size(me->hash_table);
+}
+
+struct LookupReturn
+KHashTable__lookup(struct KHashTable *me, EntryType key)
+{
+    if (me == NULL || me->hash_table == NULL)
+        return (struct LookupReturn){.success = false, .timestamp = 0};
+    khiter_t k = kh_get(64, me->hash_table, key);
+    bool found = (k != kh_end(me->hash_table));
+    uint64_t value = kh_value(me->hash_table, k);
+    return (struct LookupReturn){.success = found, .timestamp = value};
+}
+
+/// @return Returns whether we inserted, replaced, or errored.
+enum PutUniqueStatus
+KHashTable__put_unique(struct KHashTable *me,
+                       EntryType key,
+                       TimeStampType value)
+{
+
+    if (me == NULL || me->hash_table == NULL)
+        return LOOKUP_PUTUNIQUE_ERROR;
+
+    int ret = 0;
+    khint_t k = kh_put(64, me->hash_table, key, &ret);
+    if (ret == -1)
+        return LOOKUP_PUTUNIQUE_ERROR;
+    kh_value(me->hash_table, k) = value;
+
+    // NOTE The value of 'ret' is 0 if the key exists; it is 1 or 2 if
+    //      the bucket was empty or deleted (respectively). This is why
+    //      I test for a value of zero, since the other two numbers both
+    //      imply an insertion.
+    return ret == 0 ? LOOKUP_PUTUNIQUE_REPLACE_VALUE
+                    : LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE;
+}
+
+struct LookupReturn
+KHashTable__remove(struct KHashTable *const me, EntryType const key)
+{
+    if (me == NULL || me->hash_table == NULL)
+        return (struct LookupReturn){.success = false, .timestamp = 0};
+
+    khiter_t k;
+    k = kh_get(64, me->hash_table, key);
+    bool const found = (k != kh_end(me->hash_table));
+    uint64_t const stolen_value = kh_value(me->hash_table, k);
+    kh_del(64, me->hash_table, k);
+    // NOTE We assume that a found item implies a successful deletion.
+    //      This obviously means that this is not thread safe.
+    return (struct LookupReturn){.success = found,
+                                 .timestamp = (TimeStampType)stolen_value};
+}
+
+bool
+KHashTable__write(struct KHashTable const *const me,
+                  FILE *const stream,
+                  bool const newline)
+{
+    if (me == NULL || me->hash_table == NULL)
+        return false;
+    fprintf(stream, "{");
+    for (khiter_t k = kh_begin(me->hash_table); k != kh_end(me->hash_table);
+         ++k) {
+        // NOTE We could remove the trailing comma if we keep track of
+        //      how many items we are printing versus how many we have
+        //      already printed. When we see the last item, then we do
+        //      not print the trailing comma. Alternatively, we could
+        //      print the first item (if it exists) without the trailing
+        //      comma and then print all other items with a leading
+        //      comma. I don't feel like doing these things though.
+        if (kh_exist(me->hash_table, k)) {
+            fprintf(stream,
+                    "%" PRIu64 ": %" PRIu64 ", ",
+                    kh_key(me->hash_table, k),
+                    kh_value(me->hash_table, k));
+        }
+    }
+    fprintf(stream, "}%s", newline ? "\n" : "");
+    return true;
+}
+
+void
+KHashTable__destroy(struct KHashTable *me)
+{
+    if (me == NULL || me->hash_table == NULL)
+        return;
+
+    kh_destroy(64, me->hash_table);
+}

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -19,7 +19,7 @@
 KHASH_MAP_INIT_INT64(64, uint64_t)
 
 bool
-KHashTable__init(struct KHashTable *me)
+KHashTable__init(struct KHashTable *const me)
 {
     if (me == NULL)
         return false;

--- a/src/lib/lookup/k_hash_table.c
+++ b/src/lib/lookup/k_hash_table.c
@@ -51,9 +51,9 @@ KHashTable__lookup(struct KHashTable const *const me, EntryType key)
 
 /// @return Returns whether we inserted, replaced, or errored.
 enum PutUniqueStatus
-KHashTable__put_unique(struct KHashTable *const me,
-                       EntryType const key,
-                       TimeStampType const value)
+KHashTable__put(struct KHashTable *const me,
+                EntryType const key,
+                TimeStampType const value)
 {
 
     if (me == NULL || me->hash_table == NULL)

--- a/src/lib/lookup/khash.h
+++ b/src/lib/lookup/khash.h
@@ -1,0 +1,627 @@
+/* The MIT License
+
+   Copyright (c) 2008, 2009, 2011 by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  An example:
+
+#include "khash.h"
+KHASH_MAP_INIT_INT(32, char)
+int main() {
+	int ret, is_missing;
+	khiter_t k;
+	khash_t(32) *h = kh_init(32);
+	k = kh_put(32, h, 5, &ret);
+	kh_value(h, k) = 10;
+	k = kh_get(32, h, 10);
+	is_missing = (k == kh_end(h));
+	k = kh_get(32, h, 5);
+	kh_del(32, h, k);
+	for (k = kh_begin(h); k != kh_end(h); ++k)
+		if (kh_exist(h, k)) kh_value(h, k) = 1;
+	kh_destroy(32, h);
+	return 0;
+}
+*/
+
+/*
+  2013-05-02 (0.2.8):
+
+	* Use quadratic probing. When the capacity is power of 2, stepping function
+	  i*(i+1)/2 guarantees to traverse each bucket. It is better than double
+	  hashing on cache performance and is more robust than linear probing.
+
+	  In theory, double hashing should be more robust than quadratic probing.
+	  However, my implementation is probably not for large hash tables, because
+	  the second hash function is closely tied to the first hash function,
+	  which reduce the effectiveness of double hashing.
+
+	Reference: http://research.cs.vt.edu/AVresearch/hashing/quadratic.php
+
+  2011-12-29 (0.2.7):
+
+    * Minor code clean up; no actual effect.
+
+  2011-09-16 (0.2.6):
+
+	* The capacity is a power of 2. This seems to dramatically improve the
+	  speed for simple keys. Thank Zilong Tan for the suggestion. Reference:
+
+	   - http://code.google.com/p/ulib/
+	   - http://nothings.org/computer/judy/
+
+	* Allow to optionally use linear probing which usually has better
+	  performance for random input. Double hashing is still the default as it
+	  is more robust to certain non-random input.
+
+	* Added Wang's integer hash function (not used by default). This hash
+	  function is more robust to certain non-random input.
+
+  2011-02-14 (0.2.5):
+
+    * Allow to declare global functions.
+
+  2009-09-26 (0.2.4):
+
+    * Improve portability
+
+  2008-09-19 (0.2.3):
+
+	* Corrected the example
+	* Improved interfaces
+
+  2008-09-11 (0.2.2):
+
+	* Improved speed a little in kh_put()
+
+  2008-09-10 (0.2.1):
+
+	* Added kh_clear()
+	* Fixed a compiling error
+
+  2008-09-02 (0.2.0):
+
+	* Changed to token concatenation which increases flexibility.
+
+  2008-08-31 (0.1.2):
+
+	* Fixed a bug in kh_get(), which has not been tested previously.
+
+  2008-08-31 (0.1.1):
+
+	* Added destructor
+*/
+
+
+#ifndef __AC_KHASH_H
+#define __AC_KHASH_H
+
+/*!
+  @header
+
+  Generic hash table library.
+ */
+
+#define AC_VERSION_KHASH_H "0.2.8"
+
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+/* compiler specific configuration */
+
+#if UINT_MAX == 0xffffffffu
+typedef unsigned int khint32_t;
+#elif ULONG_MAX == 0xffffffffu
+typedef unsigned long khint32_t;
+#endif
+
+#if ULONG_MAX == ULLONG_MAX
+typedef unsigned long khint64_t;
+#else
+typedef unsigned long long khint64_t;
+#endif
+
+#ifndef kh_inline
+#ifdef _MSC_VER
+#define kh_inline __inline
+#else
+#define kh_inline inline
+#endif
+#endif /* kh_inline */
+
+#ifndef klib_unused
+#if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
+#define klib_unused __attribute__ ((__unused__))
+#else
+#define klib_unused
+#endif
+#endif /* klib_unused */
+
+typedef khint32_t khint_t;
+typedef khint_t khiter_t;
+
+#define __ac_isempty(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&2)
+#define __ac_isdel(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&1)
+#define __ac_iseither(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&3)
+#define __ac_set_isdel_false(flag, i) (flag[i>>4]&=~(1ul<<((i&0xfU)<<1)))
+#define __ac_set_isempty_false(flag, i) (flag[i>>4]&=~(2ul<<((i&0xfU)<<1)))
+#define __ac_set_isboth_false(flag, i) (flag[i>>4]&=~(3ul<<((i&0xfU)<<1)))
+#define __ac_set_isdel_true(flag, i) (flag[i>>4]|=1ul<<((i&0xfU)<<1))
+
+#define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
+
+#ifndef kroundup32
+#define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#endif
+
+#ifndef kcalloc
+#define kcalloc(N,Z) calloc(N,Z)
+#endif
+#ifndef kmalloc
+#define kmalloc(Z) malloc(Z)
+#endif
+#ifndef krealloc
+#define krealloc(P,Z) realloc(P,Z)
+#endif
+#ifndef kfree
+#define kfree(P) free(P)
+#endif
+
+static const double __ac_HASH_UPPER = 0.77;
+
+#define __KHASH_TYPE(name, khkey_t, khval_t) \
+	typedef struct kh_##name##_s { \
+		khint_t n_buckets, size, n_occupied, upper_bound; \
+		khint32_t *flags; \
+		khkey_t *keys; \
+		khval_t *vals; \
+	} kh_##name##_t;
+
+#define __KHASH_PROTOTYPES(name, khkey_t, khval_t)	 					\
+	extern kh_##name##_t *kh_init_##name(void);							\
+	extern void kh_destroy_##name(kh_##name##_t *h);					\
+	extern void kh_clear_##name(kh_##name##_t *h);						\
+	extern khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key); 	\
+	extern int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets); \
+	extern khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret); \
+	extern void kh_del_##name(kh_##name##_t *h, khint_t x);
+
+#define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	SCOPE kh_##name##_t *kh_init_##name(void) {							\
+		return (kh_##name##_t*)kcalloc(1, sizeof(kh_##name##_t));		\
+	}																	\
+	SCOPE void kh_destroy_##name(kh_##name##_t *h)						\
+	{																	\
+		if (h) {														\
+			kfree((void *)h->keys); kfree(h->flags);					\
+			kfree((void *)h->vals);										\
+			kfree(h);													\
+		}																\
+	}																	\
+	SCOPE void kh_clear_##name(kh_##name##_t *h)						\
+	{																	\
+		if (h && h->flags) {											\
+			memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khint32_t)); \
+			h->size = h->n_occupied = 0;								\
+		}																\
+	}																	\
+	SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) 	\
+	{																	\
+		if (h->n_buckets) {												\
+			khint_t k, i, last, mask, step = 0; \
+			mask = h->n_buckets - 1;									\
+			k = __hash_func(key); i = k & mask;							\
+			last = i; \
+			while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+				i = (i + (++step)) & mask; \
+				if (i == last) return h->n_buckets;						\
+			}															\
+			return __ac_iseither(h->flags, i)? h->n_buckets : i;		\
+		} else return 0;												\
+	}																	\
+	SCOPE int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets) \
+	{ /* This function uses 0.25*n_buckets bytes of working space instead of [sizeof(key_t+val_t)+.25]*n_buckets. */ \
+		khint32_t *new_flags = 0;										\
+		khint_t j = 1;													\
+		{																\
+			kroundup32(new_n_buckets); 									\
+			if (new_n_buckets < 4) new_n_buckets = 4;					\
+			if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0;	/* requested size is too small */ \
+			else { /* hash table size to be changed (shrink or expand); rehash */ \
+				new_flags = (khint32_t*)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t));	\
+				if (!new_flags) return -1;								\
+				memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
+				if (h->n_buckets < new_n_buckets) {	/* expand */		\
+					khkey_t *new_keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+					if (!new_keys) { kfree(new_flags); return -1; }		\
+					h->keys = new_keys;									\
+					if (kh_is_map) {									\
+						khval_t *new_vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+						if (!new_vals) { kfree(new_flags); return -1; }	\
+						h->vals = new_vals;								\
+					}													\
+				} /* otherwise shrink */								\
+			}															\
+		}																\
+		if (j) { /* rehashing is needed */								\
+			for (j = 0; j != h->n_buckets; ++j) {						\
+				if (__ac_iseither(h->flags, j) == 0) {					\
+					khkey_t key = h->keys[j];							\
+					khval_t val;										\
+					khint_t new_mask;									\
+					new_mask = new_n_buckets - 1; 						\
+					if (kh_is_map) val = h->vals[j];					\
+					__ac_set_isdel_true(h->flags, j);					\
+					while (1) { /* kick-out process; sort of like in Cuckoo hashing */ \
+						khint_t k, i, step = 0; \
+						k = __hash_func(key);							\
+						i = k & new_mask;								\
+						while (!__ac_isempty(new_flags, i)) i = (i + (++step)) & new_mask; \
+						__ac_set_isempty_false(new_flags, i);			\
+						if (i < h->n_buckets && __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */ \
+							{ khkey_t tmp = h->keys[i]; h->keys[i] = key; key = tmp; } \
+							if (kh_is_map) { khval_t tmp = h->vals[i]; h->vals[i] = val; val = tmp; } \
+							__ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */ \
+						} else { /* write the element and jump out of the loop */ \
+							h->keys[i] = key;							\
+							if (kh_is_map) h->vals[i] = val;			\
+							break;										\
+						}												\
+					}													\
+				}														\
+			}															\
+			if (h->n_buckets > new_n_buckets) { /* shrink the hash table */ \
+				h->keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+				if (kh_is_map) h->vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+			}															\
+			kfree(h->flags); /* free the working space */				\
+			h->flags = new_flags;										\
+			h->n_buckets = new_n_buckets;								\
+			h->n_occupied = h->size;									\
+			h->upper_bound = (khint_t)(h->n_buckets * __ac_HASH_UPPER + 0.5); \
+		}																\
+		return 0;														\
+	}																	\
+	SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) \
+	{																	\
+		khint_t x;														\
+		if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
+			if (h->n_buckets > (h->size<<1)) {							\
+				if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */ \
+					*ret = -1; return h->n_buckets;						\
+				}														\
+			} else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
+				*ret = -1; return h->n_buckets;							\
+			}															\
+		} /* TODO: to implement automatically shrinking; resize() already support shrinking */ \
+		{																\
+			khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0; \
+			x = site = h->n_buckets; k = __hash_func(key); i = k & mask; \
+			if (__ac_isempty(h->flags, i)) x = i; /* for speed up */	\
+			else {														\
+				last = i; \
+				while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+					if (__ac_isdel(h->flags, i)) site = i;				\
+					i = (i + (++step)) & mask; \
+					if (i == last) { x = site; break; }					\
+				}														\
+				if (x == h->n_buckets) {								\
+					if (__ac_isempty(h->flags, i) && site != h->n_buckets) x = site; \
+					else x = i;											\
+				}														\
+			}															\
+		}																\
+		if (__ac_isempty(h->flags, x)) { /* not present at all */		\
+			h->keys[x] = key;											\
+			__ac_set_isboth_false(h->flags, x);							\
+			++h->size; ++h->n_occupied;									\
+			*ret = 1;													\
+		} else if (__ac_isdel(h->flags, x)) { /* deleted */				\
+			h->keys[x] = key;											\
+			__ac_set_isboth_false(h->flags, x);							\
+			++h->size;													\
+			*ret = 2;													\
+		} else *ret = 0; /* Don't touch h->keys[x] if present and not deleted */ \
+		return x;														\
+	}																	\
+	SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x)				\
+	{																	\
+		if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {			\
+			__ac_set_isdel_true(h->flags, x);							\
+			--h->size;													\
+		}																\
+	}
+
+#define KHASH_DECLARE(name, khkey_t, khval_t)		 					\
+	__KHASH_TYPE(name, khkey_t, khval_t) 								\
+	__KHASH_PROTOTYPES(name, khkey_t, khval_t)
+
+#define KHASH_INIT2(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	__KHASH_TYPE(name, khkey_t, khval_t) 								\
+	__KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+#define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+/* --- BEGIN OF HASH FUNCTIONS --- */
+
+/*! @function
+  @abstract     Integer hash function
+  @param  key   The integer [khint32_t]
+  @return       The hash value [khint_t]
+ */
+#define kh_int_hash_func(key) (khint32_t)(key)
+/*! @function
+  @abstract     Integer comparison function
+ */
+#define kh_int_hash_equal(a, b) ((a) == (b))
+/*! @function
+  @abstract     64-bit integer hash function
+  @param  key   The integer [khint64_t]
+  @return       The hash value [khint_t]
+ */
+#define kh_int64_hash_func(key) (khint32_t)((key)>>33^(key)^(key)<<11)
+/*! @function
+  @abstract     64-bit integer comparison function
+ */
+#define kh_int64_hash_equal(a, b) ((a) == (b))
+/*! @function
+  @abstract     const char* hash function
+  @param  s     Pointer to a null terminated string
+  @return       The hash value
+ */
+static kh_inline khint_t __ac_X31_hash_string(const char *s)
+{
+	khint_t h = (khint_t)*s;
+	if (h) for (++s ; *s; ++s) h = (h << 5) - h + (khint_t)*s;
+	return h;
+}
+/*! @function
+  @abstract     Another interface to const char* hash function
+  @param  key   Pointer to a null terminated string [const char*]
+  @return       The hash value [khint_t]
+ */
+#define kh_str_hash_func(key) __ac_X31_hash_string(key)
+/*! @function
+  @abstract     Const char* comparison function
+ */
+#define kh_str_hash_equal(a, b) (strcmp(a, b) == 0)
+
+static kh_inline khint_t __ac_Wang_hash(khint_t key)
+{
+    key += ~(key << 15);
+    key ^=  (key >> 10);
+    key +=  (key << 3);
+    key ^=  (key >> 6);
+    key += ~(key << 11);
+    key ^=  (key >> 16);
+    return key;
+}
+#define kh_int_hash_func2(key) __ac_Wang_hash((khint_t)key)
+
+/* --- END OF HASH FUNCTIONS --- */
+
+/* Other convenient macros... */
+
+/*!
+  @abstract Type of the hash table.
+  @param  name  Name of the hash table [symbol]
+ */
+#define khash_t(name) kh_##name##_t
+
+/*! @function
+  @abstract     Initiate a hash table.
+  @param  name  Name of the hash table [symbol]
+  @return       Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_init(name) kh_init_##name()
+
+/*! @function
+  @abstract     Destroy a hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_destroy(name, h) kh_destroy_##name(h)
+
+/*! @function
+  @abstract     Reset a hash table without deallocating memory.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+ */
+#define kh_clear(name, h) kh_clear_##name(h)
+
+/*! @function
+  @abstract     Resize a hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  s     New size [khint_t]
+ */
+#define kh_resize(name, h, s) kh_resize_##name(h, s)
+
+/*! @function
+  @abstract     Insert a key to the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Key [type of keys]
+  @param  r     Extra return code: -1 if the operation failed;
+                0 if the key is present in the hash table;
+                1 if the bucket is empty (never used); 2 if the element in
+				the bucket has been deleted [int*]
+  @return       Iterator to the inserted element [khint_t]
+ */
+#define kh_put(name, h, k, r) kh_put_##name(h, k, r)
+
+/*! @function
+  @abstract     Retrieve a key from the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Key [type of keys]
+  @return       Iterator to the found element, or kh_end(h) if the element is absent [khint_t]
+ */
+#define kh_get(name, h, k) kh_get_##name(h, k)
+
+/*! @function
+  @abstract     Remove a key from the hash table.
+  @param  name  Name of the hash table [symbol]
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  k     Iterator to the element to be deleted [khint_t]
+ */
+#define kh_del(name, h, k) kh_del_##name(h, k)
+
+/*! @function
+  @abstract     Test whether a bucket contains data.
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       1 if containing data; 0 otherwise [int]
+ */
+#define kh_exist(h, x) (!__ac_iseither((h)->flags, (x)))
+
+/*! @function
+  @abstract     Get key given an iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       Key [type of keys]
+ */
+#define kh_key(h, x) ((h)->keys[x])
+
+/*! @function
+  @abstract     Get value given an iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  x     Iterator to the bucket [khint_t]
+  @return       Value [type of values]
+  @discussion   For hash sets, calling this results in segfault.
+ */
+#define kh_val(h, x) ((h)->vals[x])
+
+/*! @function
+  @abstract     Alias of kh_val()
+ */
+#define kh_value(h, x) ((h)->vals[x])
+
+/*! @function
+  @abstract     Get the start iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       The start iterator [khint_t]
+ */
+#define kh_begin(h) (khint_t)(0)
+
+/*! @function
+  @abstract     Get the end iterator
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       The end iterator [khint_t]
+ */
+#define kh_end(h) ((h)->n_buckets)
+
+/*! @function
+  @abstract     Get the number of elements in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       Number of elements in the hash table [khint_t]
+ */
+#define kh_size(h) ((h)->size)
+
+/*! @function
+  @abstract     Get the number of buckets in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @return       Number of buckets in the hash table [khint_t]
+ */
+#define kh_n_buckets(h) ((h)->n_buckets)
+
+/*! @function
+  @abstract     Iterate over the entries in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  kvar  Variable to which key will be assigned
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach(h, kvar, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(kvar) = kh_key(h,__i);								\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
+/*! @function
+  @abstract     Iterate over the values in the hash table
+  @param  h     Pointer to the hash table [khash_t(name)*]
+  @param  vvar  Variable to which value will be assigned
+  @param  code  Block of code to execute
+ */
+#define kh_foreach_value(h, vvar, code) { khint_t __i;		\
+	for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		if (!kh_exist(h,__i)) continue;						\
+		(vvar) = kh_val(h,__i);								\
+		code;												\
+	} }
+
+/* More convenient interfaces */
+
+/*! @function
+  @abstract     Instantiate a hash set containing integer keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_INT(name)										\
+	KHASH_INIT(name, khint32_t, char, 0, kh_int_hash_func, kh_int_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing integer keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_INT(name, khval_t)								\
+	KHASH_INIT(name, khint32_t, khval_t, 1, kh_int_hash_func, kh_int_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash set containing 64-bit integer keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_INT64(name)										\
+	KHASH_INIT(name, khint64_t, char, 0, kh_int64_hash_func, kh_int64_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing 64-bit integer keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_INT64(name, khval_t)								\
+	KHASH_INIT(name, khint64_t, khval_t, 1, kh_int64_hash_func, kh_int64_hash_equal)
+
+typedef const char *kh_cstr_t;
+/*! @function
+  @abstract     Instantiate a hash map containing const char* keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_STR(name)										\
+	KHASH_INIT(name, kh_cstr_t, char, 0, kh_str_hash_func, kh_str_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing const char* keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_STR(name, khval_t)								\
+	KHASH_INIT(name, kh_cstr_t, khval_t, 1, kh_str_hash_func, kh_str_hash_equal)
+
+#endif /* __AC_KHASH_H */

--- a/src/lib/lookup/khash.h
+++ b/src/lib/lookup/khash.h
@@ -1,3 +1,11 @@
+/* All text besides this comment belong to the original text. I chose to copy
+ * the file directly rather than creating a submodule for expediency.
+ *
+ * Retrival Information:
+ * Date/Time: 2024 Aug 13 at 10 AM
+ * URL: https://github.com/attractivechaos/klib/blob/master/khash.h
+ * Commit hash: 29445495262cf34f4c3b82d3917ac83f3e1f3f58
+ */
 /* The MIT License
 
    Copyright (c) 2008, 2009, 2011 by Attractive Chaos <attractor@live.co.uk>

--- a/src/lib/lookup/meson.build
+++ b/src/lib/lookup/meson.build
@@ -11,7 +11,7 @@ lookup_lib = library(
         'boost_hash_table.cpp',
     ],
     dependencies: [
-        boost_dep,
+        # boost_dep,
         common_dep,
         glib_dep,
         math_dep,

--- a/src/lib/lookup/meson.build
+++ b/src/lib/lookup/meson.build
@@ -8,6 +8,7 @@ lookup_lib = library(
         'parallel_list.c',
         'evicting_hash_table.c',
         'k_hash_table.c',
+        'boost_hash_table.cpp',
     ],
     dependencies: [
         common_dep,

--- a/src/lib/lookup/meson.build
+++ b/src/lib/lookup/meson.build
@@ -1,21 +1,26 @@
+lookup_inc = include_directories('include', '.')
+
+lookup_lib = library(
+    'lookup_lib',
+    [
+        'hash_table.c',
+        'parallel_hash_table.c',
+        'parallel_list.c',
+        'evicting_hash_table.c',
+        'k_hash_table.c',
+    ],
+    dependencies: [
+        common_dep,
+        glib_dep,
+        math_dep,
+        thread_dep,
+        hash_dep,
+    ],
+    include_directories: lookup_inc,
+)
+
 lookup_dep = declare_dependency(
-    link_with: library(
-        'lookup_lib',
-        [
-            'hash_table.c',
-            'parallel_hash_table.c',
-            'parallel_list.c',
-            'evicting_hash_table.c',
-        ],
-        dependencies: [
-            common_dep,
-            glib_dep,
-            math_dep,
-            thread_dep,
-            hash_dep,
-        ],
-        include_directories: include_directories('include'),
-    ),
+    link_with: lookup_lib,
     dependencies: [
         common_dep,
         glib_dep,
@@ -23,5 +28,5 @@ lookup_dep = declare_dependency(
         math_dep,
         thread_dep,
     ],
-    include_directories: include_directories('include'),
+    include_directories: lookup_inc,
 )

--- a/src/lib/lookup/meson.build
+++ b/src/lib/lookup/meson.build
@@ -11,6 +11,7 @@ lookup_lib = library(
         'boost_hash_table.cpp',
     ],
     dependencies: [
+        boost_dep,
         common_dep,
         glib_dep,
         math_dep,

--- a/src/lib/lookup/meson.build
+++ b/src/lib/lookup/meson.build
@@ -11,7 +11,7 @@ lookup_lib = library(
         'boost_hash_table.cpp',
     ],
     dependencies: [
-        # boost_dep,
+        boost_dep,
         common_dep,
         glib_dep,
         math_dep,

--- a/src/lib/lookup/parallel_hash_table.c
+++ b/src/lib/lookup/parallel_hash_table.c
@@ -22,16 +22,14 @@ ParallelHashTable__init(struct ParallelHashTable *me, size_t num_buckets)
 }
 
 bool
-ParallelHashTable__put_unique(struct ParallelHashTable *me,
-                              EntryType entry,
-                              TimeStampType timestamp)
+ParallelHashTable__put(struct ParallelHashTable *me,
+                       EntryType entry,
+                       TimeStampType timestamp)
 {
     if (me == NULL || me->table == NULL || me->length == 0)
         return false;
     Hash64BitType hash = splitmix64_hash(entry);
-    return ParallelList__put_unique(&me->table[hash % me->length],
-                                    entry,
-                                    timestamp);
+    return ParallelList__put(&me->table[hash % me->length], entry, timestamp);
 }
 
 struct LookupReturn

--- a/src/lib/lookup/parallel_list.c
+++ b/src/lib/lookup/parallel_list.c
@@ -68,9 +68,9 @@ ParallelList__pop_node(struct ParallelList *me, EntryType entry)
  *  @note   Splay the input.
  */
 bool
-ParallelList__put_unique(struct ParallelList *me,
-                         EntryType entry,
-                         TimeStampType timestamp)
+ParallelList__put(struct ParallelList *me,
+                  EntryType entry,
+                  TimeStampType timestamp)
 {
     if (me == NULL) {
         return false;

--- a/src/mrc/average_eviction_time/average_eviction_time.c
+++ b/src/mrc/average_eviction_time/average_eviction_time.c
@@ -88,18 +88,14 @@ AverageEvictionTime__access_item(struct AverageEvictionTime *me,
         // We subtract an extra one so that the reuse_time between two
         // neighbouring accesses is 0.
         uint64_t const reuse_time = me->current_time_stamp - old_timestamp - 1;
-        if (HashTable__put_unique(&me->hash_table,
-                                  entry,
-                                  me->current_time_stamp) !=
+        if (HashTable__put(&me->hash_table, entry, me->current_time_stamp) !=
             LOOKUP_PUTUNIQUE_REPLACE_VALUE)
             LOGGER_WARN("failed to replace value in hash table");
         if (!Histogram__insert_finite(&me->histogram, reuse_time))
             LOGGER_WARN("failed to insert into histogram");
         ++me->current_time_stamp;
     } else {
-        if (HashTable__put_unique(&me->hash_table,
-                                  entry,
-                                  me->current_time_stamp) !=
+        if (HashTable__put(&me->hash_table, entry, me->current_time_stamp) !=
             LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE)
             LOGGER_WARN("failed to insert into hash table");
         if (!Histogram__insert_infinite(&me->histogram))

--- a/src/mrc/olken/include/olken/olken.h
+++ b/src/mrc/olken/include/olken/olken.h
@@ -16,7 +16,7 @@
 
 struct Olken {
     struct Tree tree;
-    struct HashTable hash_table;
+    struct KHashTable hash_table;
     struct Histogram histogram;
     TimeStampType current_time_stamp;
 };
@@ -81,7 +81,7 @@ Olken__get_histogram(struct Olken const *const me,
 inline size_t
 Olken__get_cardinality(struct Olken const *const me)
 {
-    return HashTable__get_size(&me->hash_table);
+    return KHashTable__get_size(&me->hash_table);
 }
 
 /// @brief  Lookup a value in Olken.
@@ -90,7 +90,7 @@ Olken__get_cardinality(struct Olken const *const me)
 inline struct LookupReturn
 Olken__lookup(struct Olken const *const me, EntryType const key)
 {
-    return HashTable__lookup(&me->hash_table, key);
+    return KHashTable__lookup(&me->hash_table, key);
 }
 
 /// @brief  Lookup a value in Olken.
@@ -101,5 +101,5 @@ Olken__put(struct Olken *const me,
            EntryType const key,
            TimeStampType const value)
 {
-    return HashTable__put_unique(&me->hash_table, key, value);
+    return KHashTable__put_unique(&me->hash_table, key, value);
 }

--- a/src/mrc/olken/include/olken/olken.h
+++ b/src/mrc/olken/include/olken/olken.h
@@ -101,5 +101,5 @@ Olken__put(struct Olken *const me,
            EntryType const key,
            TimeStampType const value)
 {
-    return KHashTable__put_unique(&me->hash_table, key, value);
+    return KHashTable__put(&me->hash_table, key, value);
 }

--- a/src/mrc/olken/include/olken/olken.h
+++ b/src/mrc/olken/include/olken/olken.h
@@ -6,6 +6,7 @@
 #include <glib.h>
 
 #include "histogram/histogram.h"
+#include "lookup/boost_hash_table.h"
 #include "lookup/hash_table.h"
 #include "lookup/k_hash_table.h"
 #include "lookup/lookup.h"
@@ -16,7 +17,7 @@
 
 struct Olken {
     struct Tree tree;
-    struct KHashTable hash_table;
+    struct BoostHashTable hash_table;
     struct Histogram histogram;
     TimeStampType current_time_stamp;
 };
@@ -81,7 +82,7 @@ Olken__get_histogram(struct Olken const *const me,
 inline size_t
 Olken__get_cardinality(struct Olken const *const me)
 {
-    return KHashTable__get_size(&me->hash_table);
+    return BoostHashTable__get_size(&me->hash_table);
 }
 
 /// @brief  Lookup a value in Olken.
@@ -90,7 +91,7 @@ Olken__get_cardinality(struct Olken const *const me)
 inline struct LookupReturn
 Olken__lookup(struct Olken const *const me, EntryType const key)
 {
-    return KHashTable__lookup(&me->hash_table, key);
+    return BoostHashTable__lookup(&me->hash_table, key);
 }
 
 /// @brief  Lookup a value in Olken.
@@ -101,5 +102,5 @@ Olken__put(struct Olken *const me,
            EntryType const key,
            TimeStampType const value)
 {
-    return KHashTable__put(&me->hash_table, key, value);
+    return BoostHashTable__put(&me->hash_table, key, value);
 }

--- a/src/mrc/olken/include/olken/olken.h
+++ b/src/mrc/olken/include/olken/olken.h
@@ -16,7 +16,7 @@
 
 struct Olken {
     struct Tree tree;
-    struct KHashTable hash_table;
+    struct HashTable hash_table;
     struct Histogram histogram;
     TimeStampType current_time_stamp;
 };
@@ -81,7 +81,7 @@ Olken__get_histogram(struct Olken const *const me,
 inline size_t
 Olken__get_cardinality(struct Olken const *const me)
 {
-    return KHashTable__get_size(&me->hash_table);
+    return HashTable__get_size(&me->hash_table);
 }
 
 /// @brief  Lookup a value in Olken.
@@ -90,7 +90,7 @@ Olken__get_cardinality(struct Olken const *const me)
 inline struct LookupReturn
 Olken__lookup(struct Olken const *const me, EntryType const key)
 {
-    return KHashTable__lookup(&me->hash_table, key);
+    return HashTable__lookup(&me->hash_table, key);
 }
 
 /// @brief  Lookup a value in Olken.
@@ -101,5 +101,5 @@ Olken__put(struct Olken *const me,
            EntryType const key,
            TimeStampType const value)
 {
-    return KHashTable__put_unique(&me->hash_table, key, value);
+    return HashTable__put_unique(&me->hash_table, key, value);
 }

--- a/src/mrc/olken/include/olken/olken.h
+++ b/src/mrc/olken/include/olken/olken.h
@@ -15,7 +15,7 @@
 
 struct Olken {
     struct Tree tree;
-    struct HashTable hash_table;
+    struct KHashTable hash_table;
     struct Histogram histogram;
     TimeStampType current_time_stamp;
 };

--- a/src/mrc/olken/include/olken/olken.h
+++ b/src/mrc/olken/include/olken/olken.h
@@ -7,11 +7,11 @@
 
 #include "histogram/histogram.h"
 #include "lookup/hash_table.h"
+#include "lookup/k_hash_table.h"
 #include "miss_rate_curve/miss_rate_curve.h"
 #include "tree/types.h"
 #include "types/entry_type.h"
 #include "types/time_stamp_type.h"
-#include "unused/mark_unused.h"
 
 struct Olken {
     struct Tree tree;

--- a/src/mrc/olken/include/olken/olken.h
+++ b/src/mrc/olken/include/olken/olken.h
@@ -8,6 +8,7 @@
 #include "histogram/histogram.h"
 #include "lookup/hash_table.h"
 #include "lookup/k_hash_table.h"
+#include "lookup/lookup.h"
 #include "miss_rate_curve/miss_rate_curve.h"
 #include "tree/types.h"
 #include "types/entry_type.h"
@@ -75,3 +76,30 @@ Olken__destroy(struct Olken *const me);
 bool
 Olken__get_histogram(struct Olken const *const me,
                      struct Histogram const **const histogram);
+
+/// @brief  Get the cardinality of the current working set size.
+inline size_t
+Olken__get_cardinality(struct Olken const *const me)
+{
+    return KHashTable__get_size(&me->hash_table);
+}
+
+/// @brief  Lookup a value in Olken.
+/// @note   This is simply to allow changing the implementation of the
+///         hash table without breaking dependencies.
+inline struct LookupReturn
+Olken__lookup(struct Olken const *const me, EntryType const key)
+{
+    return KHashTable__lookup(&me->hash_table, key);
+}
+
+/// @brief  Lookup a value in Olken.
+/// @note   This is simply to allow changing the implementation of the
+///         hash table without breaking dependencies.
+inline enum PutUniqueStatus
+Olken__put(struct Olken *const me,
+           EntryType const key,
+           TimeStampType const value)
+{
+    return KHashTable__put_unique(&me->hash_table, key, value);
+}

--- a/src/mrc/olken/olken.c
+++ b/src/mrc/olken/olken.c
@@ -6,6 +6,7 @@
 
 #include "histogram/histogram.h"
 #include "lookup/hash_table.h"
+#include "lookup/k_hash_table.h"
 #include "lookup/lookup.h"
 #include "miss_rate_curve/miss_rate_curve.h"
 #include "olken/olken.h"
@@ -13,6 +14,7 @@
 #include "tree/sleator_tree.h"
 #include "types/entry_type.h"
 #include "types/time_stamp_type.h"
+#include "unused/mark_unused.h"
 
 static bool
 initialize(struct Olken *const me,

--- a/src/mrc/olken/olken.c
+++ b/src/mrc/olken/olken.c
@@ -28,7 +28,7 @@ initialize(struct Olken *const me,
     if (!tree__init(&me->tree)) {
         goto tree_error;
     }
-    if (!HashTable__init(&me->hash_table)) {
+    if (!KHashTable__init(&me->hash_table)) {
         goto hash_table_error;
     }
     if (!Histogram__init(&me->histogram,
@@ -41,7 +41,7 @@ initialize(struct Olken *const me,
     return true;
 
 histogram_error:
-    HashTable__destroy(&me->hash_table);
+    KHashTable__destroy(&me->hash_table);
 hash_table_error:
     tree__destroy(&me->tree);
 tree_error:
@@ -73,7 +73,7 @@ Olken__init_full(struct Olken *const me,
 bool
 Olken__remove_item(struct Olken *me, EntryType entry)
 {
-    struct LookupReturn r = HashTable__remove(&me->hash_table, entry);
+    struct LookupReturn r = KHashTable__remove(&me->hash_table, entry);
     if (!r.success) {
         return false;
     }
@@ -101,7 +101,9 @@ Olken__update_stack(struct Olken *me, EntryType entry, TimeStampType timestamp)
     if (!tree__sleator_insert(&me->tree, me->current_time_stamp)) {
         return UINT64_MAX;
     }
-    if (HashTable__put_unique(&me->hash_table, entry, me->current_time_stamp) !=
+    if (KHashTable__put_unique(&me->hash_table,
+                               entry,
+                               me->current_time_stamp) !=
         LOOKUP_PUTUNIQUE_REPLACE_VALUE) {
         return UINT64_MAX;
     }
@@ -115,7 +117,9 @@ Olken__insert_stack(struct Olken *me, EntryType entry)
     if (me == NULL) {
         return false;
     }
-    if (HashTable__put_unique(&me->hash_table, entry, me->current_time_stamp) !=
+    if (KHashTable__put_unique(&me->hash_table,
+                               entry,
+                               me->current_time_stamp) !=
         LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE) {
         return false;
     }
@@ -133,7 +137,7 @@ Olken__access_item(struct Olken *const me, EntryType const entry)
         return false;
     }
 
-    struct LookupReturn found = HashTable__lookup(&me->hash_table, entry);
+    struct LookupReturn found = KHashTable__lookup(&me->hash_table, entry);
     if (found.success) {
         uint64_t distance = Olken__update_stack(me, entry, found.timestamp);
         if (distance == UINT64_MAX) {
@@ -184,7 +188,7 @@ Olken__destroy(struct Olken *const me)
         return;
     }
     tree__destroy(&me->tree);
-    HashTable__destroy(&me->hash_table);
+    KHashTable__destroy(&me->hash_table);
     Histogram__destroy(&me->histogram);
     *me = (struct Olken){0};
 }

--- a/src/mrc/olken/olken.c
+++ b/src/mrc/olken/olken.c
@@ -28,7 +28,7 @@ initialize(struct Olken *const me,
     if (!tree__init(&me->tree)) {
         goto tree_error;
     }
-    if (!KHashTable__init(&me->hash_table)) {
+    if (!HashTable__init(&me->hash_table)) {
         goto hash_table_error;
     }
     if (!Histogram__init(&me->histogram,
@@ -41,7 +41,7 @@ initialize(struct Olken *const me,
     return true;
 
 histogram_error:
-    KHashTable__destroy(&me->hash_table);
+    HashTable__destroy(&me->hash_table);
 hash_table_error:
     tree__destroy(&me->tree);
 tree_error:
@@ -73,7 +73,7 @@ Olken__init_full(struct Olken *const me,
 bool
 Olken__remove_item(struct Olken *me, EntryType entry)
 {
-    struct LookupReturn r = KHashTable__remove(&me->hash_table, entry);
+    struct LookupReturn r = HashTable__remove(&me->hash_table, entry);
     if (!r.success) {
         return false;
     }
@@ -101,9 +101,7 @@ Olken__update_stack(struct Olken *me, EntryType entry, TimeStampType timestamp)
     if (!tree__sleator_insert(&me->tree, me->current_time_stamp)) {
         return UINT64_MAX;
     }
-    if (KHashTable__put_unique(&me->hash_table,
-                               entry,
-                               me->current_time_stamp) !=
+    if (HashTable__put_unique(&me->hash_table, entry, me->current_time_stamp) !=
         LOOKUP_PUTUNIQUE_REPLACE_VALUE) {
         return UINT64_MAX;
     }
@@ -117,9 +115,7 @@ Olken__insert_stack(struct Olken *me, EntryType entry)
     if (me == NULL) {
         return false;
     }
-    if (KHashTable__put_unique(&me->hash_table,
-                               entry,
-                               me->current_time_stamp) !=
+    if (HashTable__put_unique(&me->hash_table, entry, me->current_time_stamp) !=
         LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE) {
         return false;
     }
@@ -137,7 +133,7 @@ Olken__access_item(struct Olken *const me, EntryType const entry)
         return false;
     }
 
-    struct LookupReturn found = KHashTable__lookup(&me->hash_table, entry);
+    struct LookupReturn found = HashTable__lookup(&me->hash_table, entry);
     if (found.success) {
         uint64_t distance = Olken__update_stack(me, entry, found.timestamp);
         if (distance == UINT64_MAX) {
@@ -188,7 +184,7 @@ Olken__destroy(struct Olken *const me)
         return;
     }
     tree__destroy(&me->tree);
-    KHashTable__destroy(&me->hash_table);
+    HashTable__destroy(&me->hash_table);
     Histogram__destroy(&me->histogram);
     *me = (struct Olken){0};
 }

--- a/src/mrc/olken/olken.c
+++ b/src/mrc/olken/olken.c
@@ -101,9 +101,7 @@ Olken__update_stack(struct Olken *me, EntryType entry, TimeStampType timestamp)
     if (!tree__sleator_insert(&me->tree, me->current_time_stamp)) {
         return UINT64_MAX;
     }
-    if (KHashTable__put_unique(&me->hash_table,
-                               entry,
-                               me->current_time_stamp) !=
+    if (KHashTable__put(&me->hash_table, entry, me->current_time_stamp) !=
         LOOKUP_PUTUNIQUE_REPLACE_VALUE) {
         return UINT64_MAX;
     }
@@ -117,9 +115,7 @@ Olken__insert_stack(struct Olken *me, EntryType entry)
     if (me == NULL) {
         return false;
     }
-    if (KHashTable__put_unique(&me->hash_table,
-                               entry,
-                               me->current_time_stamp) !=
+    if (KHashTable__put(&me->hash_table, entry, me->current_time_stamp) !=
         LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE) {
         return false;
     }

--- a/src/mrc/quickmrc/quickmrc.c
+++ b/src/mrc/quickmrc/quickmrc.c
@@ -80,7 +80,7 @@ QuickMRC__access_item(struct QuickMRC *me, EntryType entry)
             return false;
         }
         TimeStampType new_timestamp = me->buckets.buckets[0].max_timestamp;
-        HashTable__put_unique(&me->hash_table, entry, new_timestamp);
+        HashTable__put(&me->hash_table, entry, new_timestamp);
         Histogram__insert_scaled_finite(&me->histogram, stack_dist, me->scale);
     } else {
         if (!QuickMRCBuckets__insert_new(&me->buckets)) {
@@ -90,7 +90,7 @@ QuickMRC__access_item(struct QuickMRC *me, EntryType entry)
             return false;
         }
         TimeStampType new_timestamp = me->buckets.buckets[0].max_timestamp;
-        HashTable__put_unique(&me->hash_table, entry, new_timestamp);
+        HashTable__put(&me->hash_table, entry, new_timestamp);
     }
 
     return true;

--- a/src/mrc/shards/fixed_rate_shards.c
+++ b/src/mrc/shards/fixed_rate_shards.c
@@ -122,7 +122,7 @@ FixedRateShards__access_item(struct FixedRateShards *me, EntryType entry)
     }
     ++me->num_entries_processed;
 
-    struct LookupReturn found = HashTable__lookup(&me->olken.hash_table, entry);
+    struct LookupReturn found = Olken__lookup(&me->olken, entry);
     if (found.success) {
         uint64_t distance =
             tree__reverse_rank(&me->olken.tree, (KeyType)found.timestamp);
@@ -132,9 +132,7 @@ FixedRateShards__access_item(struct FixedRateShards *me, EntryType entry)
                                  (KeyType)me->olken.current_time_stamp);
         assert(r && "insert should not fail");
         enum PutUniqueStatus s =
-            HashTable__put_unique(&me->olken.hash_table,
-                                  entry,
-                                  me->olken.current_time_stamp);
+            Olken__put(&me->olken, entry, me->olken.current_time_stamp);
         assert(s == LOOKUP_PUTUNIQUE_REPLACE_VALUE &&
                "update should replace value");
 #ifdef INTERVAL_STATISTICS
@@ -151,9 +149,7 @@ FixedRateShards__access_item(struct FixedRateShards *me, EntryType entry)
                                         me->scale);
     } else {
         enum PutUniqueStatus s =
-            HashTable__put_unique(&me->olken.hash_table,
-                                  entry,
-                                  me->olken.current_time_stamp);
+            Olken__put(&me->olken, entry, me->olken.current_time_stamp);
         assert(s == LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE &&
                "update should insert key/value");
         tree__sleator_insert(&me->olken.tree,

--- a/src/mrc/shards/fixed_size_shards.c
+++ b/src/mrc/shards/fixed_size_shards.c
@@ -9,7 +9,6 @@
 #include "interval_statistics/interval_statistics.h"
 #endif
 #include "logger/logger.h"
-#include "lookup/hash_table.h"
 #include "lookup/lookup.h"
 #include "miss_rate_curve/miss_rate_curve.h"
 #include "olken/olken.h"
@@ -17,6 +16,7 @@
 #include "shards/fixed_size_shards_sampler.h"
 #include "types/entry_type.h"
 #include "types/time_stamp_type.h"
+#include "unused/mark_unused.h"
 
 static bool
 initialize(struct FixedSizeShards *const me,
@@ -162,7 +162,7 @@ FixedSizeShards__access_item(struct FixedSizeShards *me, EntryType entry)
         return false;
     }
 
-    struct LookupReturn r = HashTable__lookup(&me->olken.hash_table, entry);
+    struct LookupReturn r = Olken__lookup(&me->olken, entry);
     if (r.success) {
         return update_item(me, entry, r.timestamp);
     } else {

--- a/test/lib_test/hyperloglog_test/hyperloglog_test.c
+++ b/test/lib_test/hyperloglog_test/hyperloglog_test.c
@@ -100,7 +100,7 @@ test_hyperloglog_accuracy(char const *const fpath,
     for (size_t i = 0; i < artificial_trace_length; ++i) {
         enum PutUniqueStatus s = LOOKUP_PUTUNIQUE_ERROR;
         uint64_t const x = f_next(data);
-        s = HashTable__put_unique(&ht, x, 0);
+        s = HashTable__put(&ht, x, 0);
         EvictingHashTable__try_put(&eht, x, 0);
         if (s == LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE &&
             FixedSizeShardsSampler__sample(&fs, x)) {

--- a/test/lib_test/lookup_test/boost_hash_table_test.c
+++ b/test/lib_test/lookup_test/boost_hash_table_test.c
@@ -1,0 +1,103 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <glib.h>
+
+#include "lookup/boost_hash_table.h"
+#include "lookup/lookup.h"
+#include "test/mytester.h"
+#include "unused/mark_unused.h"
+
+#define MAX_SIZE         10
+#define STREAM           stderr
+#define MAX_INT_PLUS_ONE (((size_t)1 << 32) + 1)
+
+static bool
+test_boost_hash(void)
+{
+    struct BoostHashTable *me = BoostHashTable__new();
+    g_assert_false(me == NULL);
+    BoostHashTable__write(me, STREAM, true);
+
+    // Test successful inserts
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
+        enum PutUniqueStatus r = BoostHashTable__put(me, i, 2 * i);
+        g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
+        BoostHashTable__write(me, STREAM, true);
+    }
+
+    // Test successful lookups
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
+        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        g_assert_true(r.success);
+        g_assert_cmpuint(r.timestamp, ==, 2 * i);
+    }
+
+    // Test unsuccessful lookups
+    for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
+        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        g_assert_false(r.success);
+    }
+
+    // Test successful replacements
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
+        enum PutUniqueStatus r = BoostHashTable__put(me, i, 3 * i);
+        g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_REPLACE_VALUE);
+        BoostHashTable__write(me, STREAM, true);
+    }
+
+    // Test successful lookups
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
+        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        g_assert_true(r.success);
+        g_assert_cmpuint(r.timestamp, ==, 3 * i);
+    }
+
+    // Test unsuccessful lookups
+    for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
+        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        g_assert_false(r.success);
+    }
+
+    // Test successful deletes
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
+        struct LookupReturn r = BoostHashTable__remove(me, i);
+        g_assert_true(r.success);
+        g_assert_cmpuint(r.timestamp, ==, 3 * i);
+        BoostHashTable__write(me, STREAM, true);
+    }
+
+    // Test unsuccessful deletes
+    for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
+        struct LookupReturn r = BoostHashTable__remove(me, i);
+        g_assert_false(r.success);
+    }
+
+    BoostHashTable__write(me, STREAM, true);
+    BoostHashTable__free(me);
+    return true;
+}
+
+/// @brief  Test the ability to store more than 4 billion elements.
+static bool
+test_large_boost_hash(void)
+{
+    struct BoostHashTable *me = BoostHashTable__new();
+
+    for (uint64_t i = 0; i < MAX_INT_PLUS_ONE; ++i) {
+        enum PutUniqueStatus r = BoostHashTable__put(me, i, 2 * i);
+        g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
+    }
+
+    BoostHashTable__free(me);
+    return true;
+}
+
+int
+main(void)
+{
+    ASSERT_FUNCTION_RETURNS_TRUE(test_boost_hash());
+    UNUSED(test_large_boost_hash);
+    return EXIT_SUCCESS;
+}

--- a/test/lib_test/lookup_test/boost_hash_table_test.c
+++ b/test/lib_test/lookup_test/boost_hash_table_test.c
@@ -10,72 +10,72 @@
 #include "unused/mark_unused.h"
 
 #define MAX_SIZE         10
-#define STREAM           stderr
+#define STREAM           stdout
 #define MAX_INT_PLUS_ONE (((size_t)1 << 32) + 1)
 
 static bool
 test_boost_hash(void)
 {
-    struct BoostHashTable *me = BoostHashTable__new();
-    g_assert_false(me == NULL);
-    BoostHashTable__write(me, STREAM, true);
+    struct BoostHashTable me = {0};
+    g_assert_true(BoostHashTable__init(&me));
+    BoostHashTable__write(&me, STREAM, true);
 
     // Test successful inserts
     for (uint64_t i = 0; i < MAX_SIZE; ++i) {
-        enum PutUniqueStatus r = BoostHashTable__put(me, i, 2 * i);
+        enum PutUniqueStatus r = BoostHashTable__put(&me, i, 2 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
-        BoostHashTable__write(me, STREAM, true);
+        BoostHashTable__write(&me, STREAM, true);
     }
 
     // Test successful lookups
     for (uint64_t i = 0; i < MAX_SIZE; ++i) {
-        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        struct LookupReturn r = BoostHashTable__lookup(&me, i);
         g_assert_true(r.success);
         g_assert_cmpuint(r.timestamp, ==, 2 * i);
     }
 
     // Test unsuccessful lookups
     for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
-        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        struct LookupReturn r = BoostHashTable__lookup(&me, i);
         g_assert_false(r.success);
     }
 
     // Test successful replacements
     for (uint64_t i = 0; i < MAX_SIZE; ++i) {
-        enum PutUniqueStatus r = BoostHashTable__put(me, i, 3 * i);
+        enum PutUniqueStatus r = BoostHashTable__put(&me, i, 3 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_REPLACE_VALUE);
-        BoostHashTable__write(me, STREAM, true);
+        BoostHashTable__write(&me, STREAM, true);
     }
 
     // Test successful lookups
     for (uint64_t i = 0; i < MAX_SIZE; ++i) {
-        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        struct LookupReturn r = BoostHashTable__lookup(&me, i);
         g_assert_true(r.success);
         g_assert_cmpuint(r.timestamp, ==, 3 * i);
     }
 
     // Test unsuccessful lookups
     for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
-        struct LookupReturn r = BoostHashTable__lookup(me, i);
+        struct LookupReturn r = BoostHashTable__lookup(&me, i);
         g_assert_false(r.success);
     }
 
     // Test successful deletes
     for (uint64_t i = 0; i < MAX_SIZE; ++i) {
-        struct LookupReturn r = BoostHashTable__remove(me, i);
+        struct LookupReturn r = BoostHashTable__remove(&me, i);
         g_assert_true(r.success);
         g_assert_cmpuint(r.timestamp, ==, 3 * i);
-        BoostHashTable__write(me, STREAM, true);
+        BoostHashTable__write(&me, STREAM, true);
     }
 
     // Test unsuccessful deletes
     for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
-        struct LookupReturn r = BoostHashTable__remove(me, i);
+        struct LookupReturn r = BoostHashTable__remove(&me, i);
         g_assert_false(r.success);
     }
 
-    BoostHashTable__write(me, STREAM, true);
-    BoostHashTable__free(me);
+    BoostHashTable__write(&me, STREAM, true);
+    BoostHashTable__destroy(&me);
     return true;
 }
 
@@ -83,14 +83,15 @@ test_boost_hash(void)
 static bool
 test_large_boost_hash(void)
 {
-    struct BoostHashTable *me = BoostHashTable__new();
+    struct BoostHashTable me = {0};
+    g_assert_true(BoostHashTable__init(&me));
 
     for (uint64_t i = 0; i < MAX_INT_PLUS_ONE; ++i) {
-        enum PutUniqueStatus r = BoostHashTable__put(me, i, 2 * i);
+        enum PutUniqueStatus r = BoostHashTable__put(&me, i, 2 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
     }
 
-    BoostHashTable__free(me);
+    BoostHashTable__destroy(&me);
     return true;
 }
 

--- a/test/lib_test/lookup_test/evicting_lookup_test.c
+++ b/test/lib_test/lookup_test/evicting_lookup_test.c
@@ -23,7 +23,7 @@ sampled_test(void)
 
     for (size_t i = 0; i < UNIQUE_KEYS; ++i) {
         KeyType key = i;
-        EvictingHashTable__put_unique(&me, key, first_val);
+        EvictingHashTable__put(&me, key, first_val);
     }
 
     bool keys[UNIQUE_KEYS] = {0};
@@ -46,7 +46,7 @@ sampled_test(void)
     for (size_t i = 0; i < UNIQUE_KEYS; ++i) {
         KeyType key = i;
         struct SampledPutReturn r =
-            EvictingHashTable__put_unique(&me, key, second_val);
+            EvictingHashTable__put(&me, key, second_val);
         if (keys[i]) {
             g_assert_cmpuint(r.status, ==, SAMPLED_UPDATED);
             g_assert_cmpuint(r.new_hash, ==, HASH_FUNCTION(key));

--- a/test/lib_test/lookup_test/k_hash_table_test.c
+++ b/test/lib_test/lookup_test/k_hash_table_test.c
@@ -7,9 +7,11 @@
 #include "lookup/k_hash_table.h"
 #include "lookup/lookup.h"
 #include "test/mytester.h"
+#include "unused/mark_unused.h"
 
-#define MAX_SIZE (1 << 20)
-#define STREAM   NULL
+#define MAX_SIZE         (1 << 20)
+#define STREAM           NULL
+#define MAX_INT_PLUS_ONE (((size_t)1 << 32) + 1)
 
 static bool
 test_khash(void)
@@ -79,12 +81,12 @@ test_khash(void)
 
 /// @brief  Test the ability to store more than 4 billion elements.
 static bool
-test_large_khash(size_t const size)
+test_large_khash(void)
 {
     struct KHashTable me = {0};
     g_assert_true(KHashTable__init(&me));
 
-    for (uint64_t i = 0; i < size; ++i) {
+    for (uint64_t i = 0; i < MAX_INT_PLUS_ONE; ++i) {
         enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 2 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
     }
@@ -97,6 +99,6 @@ int
 main(void)
 {
     ASSERT_FUNCTION_RETURNS_TRUE(test_khash());
-    ASSERT_FUNCTION_RETURNS_TRUE(test_large_khash(((size_t)1 << 32) + 1));
+    UNUSED(test_large_khash);
     return EXIT_SUCCESS;
 }

--- a/test/lib_test/lookup_test/k_hash_table_test.c
+++ b/test/lib_test/lookup_test/k_hash_table_test.c
@@ -1,0 +1,84 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <glib.h>
+
+#include "logger/logger.h"
+#include "lookup/k_hash_table.h"
+
+#include "lookup/lookup.h"
+#include "test/mytester.h"
+
+bool
+test_khash(void)
+{
+    struct KHashTable me = {0};
+    g_assert_true(KHashTable__init(&me));
+    g_assert_true(KHashTable__write(&me, stdout, true));
+
+    // Test successful lookups
+    for (uint64_t i = 0; i < 10; ++i) {
+        enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 2 * i);
+        g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
+        KHashTable__write(&me, stdout, true);
+    }
+
+    // Test successful lookups
+    for (uint64_t i = 0; i < 10; ++i) {
+        struct LookupReturn r = KHashTable__lookup(&me, i);
+        g_assert_true(r.success);
+        g_assert_cmpuint(r.timestamp, ==, 2 * i);
+    }
+
+    // Test unsuccessful lookups
+    for (uint64_t i = 10; i < 20; ++i) {
+        struct LookupReturn r = KHashTable__lookup(&me, i);
+        g_assert_false(r.success);
+    }
+
+    // Test successful replacements
+    for (uint64_t i = 0; i < 10; ++i) {
+        enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 3 * i);
+        g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_REPLACE_VALUE);
+        KHashTable__write(&me, stdout, true);
+    }
+
+    // Test successful lookups
+    for (uint64_t i = 0; i < 10; ++i) {
+        struct LookupReturn r = KHashTable__lookup(&me, i);
+        g_assert_true(r.success);
+        g_assert_cmpuint(r.timestamp, ==, 3 * i);
+    }
+
+    // Test unsuccessful lookups
+    for (uint64_t i = 10; i < 20; ++i) {
+        struct LookupReturn r = KHashTable__lookup(&me, i);
+        g_assert_false(r.success);
+    }
+
+    // Test successful deletes
+    for (uint64_t i = 0; i < 10; ++i) {
+        struct LookupReturn r = KHashTable__remove(&me, i);
+        g_assert_true(r.success);
+        g_assert_cmpuint(r.timestamp, ==, 3 * i);
+        KHashTable__write(&me, stdout, true);
+    }
+
+    // Test unsuccessful deletes
+    for (uint64_t i = 10; i < 20; ++i) {
+        struct LookupReturn r = KHashTable__remove(&me, i);
+        g_assert_false(r.success);
+    }
+
+    KHashTable__write(&me, stdout, true);
+    KHashTable__destroy(&me);
+    return true;
+}
+
+int
+main(void)
+{
+    ASSERT_FUNCTION_RETURNS_TRUE(test_khash());
+    return EXIT_SUCCESS;
+}

--- a/test/lib_test/lookup_test/k_hash_table_test.c
+++ b/test/lib_test/lookup_test/k_hash_table_test.c
@@ -4,74 +4,91 @@
 
 #include <glib.h>
 
-#include "logger/logger.h"
 #include "lookup/k_hash_table.h"
-
 #include "lookup/lookup.h"
 #include "test/mytester.h"
 
-bool
+#define MAX_SIZE (1 << 20)
+#define STREAM   NULL
+
+static bool
 test_khash(void)
 {
     struct KHashTable me = {0};
     g_assert_true(KHashTable__init(&me));
-    g_assert_true(KHashTable__write(&me, stdout, true));
+    KHashTable__write(&me, STREAM, true);
 
-    // Test successful lookups
-    for (uint64_t i = 0; i < 10; ++i) {
+    // Test successful inserts
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
         enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 2 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
-        KHashTable__write(&me, stdout, true);
+        KHashTable__write(&me, STREAM, true);
     }
 
     // Test successful lookups
-    for (uint64_t i = 0; i < 10; ++i) {
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
         struct LookupReturn r = KHashTable__lookup(&me, i);
         g_assert_true(r.success);
         g_assert_cmpuint(r.timestamp, ==, 2 * i);
     }
 
     // Test unsuccessful lookups
-    for (uint64_t i = 10; i < 20; ++i) {
+    for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
         struct LookupReturn r = KHashTable__lookup(&me, i);
         g_assert_false(r.success);
     }
 
     // Test successful replacements
-    for (uint64_t i = 0; i < 10; ++i) {
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
         enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 3 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_REPLACE_VALUE);
-        KHashTable__write(&me, stdout, true);
+        KHashTable__write(&me, STREAM, true);
     }
 
     // Test successful lookups
-    for (uint64_t i = 0; i < 10; ++i) {
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
         struct LookupReturn r = KHashTable__lookup(&me, i);
         g_assert_true(r.success);
         g_assert_cmpuint(r.timestamp, ==, 3 * i);
     }
 
     // Test unsuccessful lookups
-    for (uint64_t i = 10; i < 20; ++i) {
+    for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
         struct LookupReturn r = KHashTable__lookup(&me, i);
         g_assert_false(r.success);
     }
 
     // Test successful deletes
-    for (uint64_t i = 0; i < 10; ++i) {
+    for (uint64_t i = 0; i < MAX_SIZE; ++i) {
         struct LookupReturn r = KHashTable__remove(&me, i);
         g_assert_true(r.success);
         g_assert_cmpuint(r.timestamp, ==, 3 * i);
-        KHashTable__write(&me, stdout, true);
+        KHashTable__write(&me, STREAM, true);
     }
 
     // Test unsuccessful deletes
-    for (uint64_t i = 10; i < 20; ++i) {
+    for (uint64_t i = MAX_SIZE; i < MAX_SIZE + 10; ++i) {
         struct LookupReturn r = KHashTable__remove(&me, i);
         g_assert_false(r.success);
     }
 
-    KHashTable__write(&me, stdout, true);
+    KHashTable__write(&me, STREAM, true);
+    KHashTable__destroy(&me);
+    return true;
+}
+
+/// @brief  Test the ability to store more than 4 billion elements.
+static bool
+test_large_khash(size_t const size)
+{
+    struct KHashTable me = {0};
+    g_assert_true(KHashTable__init(&me));
+
+    for (uint64_t i = 0; i < size; ++i) {
+        enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 2 * i);
+        g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
+    }
+
     KHashTable__destroy(&me);
     return true;
 }
@@ -80,5 +97,6 @@ int
 main(void)
 {
     ASSERT_FUNCTION_RETURNS_TRUE(test_khash());
+    ASSERT_FUNCTION_RETURNS_TRUE(test_large_khash(((size_t)1 << 32) + 1));
     return EXIT_SUCCESS;
 }

--- a/test/lib_test/lookup_test/k_hash_table_test.c
+++ b/test/lib_test/lookup_test/k_hash_table_test.c
@@ -22,7 +22,7 @@ test_khash(void)
 
     // Test successful inserts
     for (uint64_t i = 0; i < MAX_SIZE; ++i) {
-        enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 2 * i);
+        enum PutUniqueStatus r = KHashTable__put(&me, i, 2 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
         KHashTable__write(&me, STREAM, true);
     }
@@ -42,7 +42,7 @@ test_khash(void)
 
     // Test successful replacements
     for (uint64_t i = 0; i < MAX_SIZE; ++i) {
-        enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 3 * i);
+        enum PutUniqueStatus r = KHashTable__put(&me, i, 3 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_REPLACE_VALUE);
         KHashTable__write(&me, STREAM, true);
     }
@@ -87,7 +87,7 @@ test_large_khash(void)
     g_assert_true(KHashTable__init(&me));
 
     for (uint64_t i = 0; i < MAX_INT_PLUS_ONE; ++i) {
-        enum PutUniqueStatus r = KHashTable__put_unique(&me, i, 2 * i);
+        enum PutUniqueStatus r = KHashTable__put(&me, i, 2 * i);
         g_assert_cmpint(r, ==, LOOKUP_PUTUNIQUE_INSERT_KEY_VALUE);
     }
 

--- a/test/lib_test/lookup_test/lookup_test.c
+++ b/test/lib_test/lookup_test/lookup_test.c
@@ -17,7 +17,7 @@ hash_table_test(void)
     g_assert_true(HashTable__init(&me));
 
     for (size_t i = 0; i < N; ++i) {
-        g_assert_true(HashTable__put_unique(&me, i, i));
+        g_assert_true(HashTable__put(&me, i, i));
     }
 
     for (size_t i = 0; i < N; ++i) {
@@ -26,7 +26,7 @@ hash_table_test(void)
     }
 
     for (size_t i = 0; i < N; ++i) {
-        g_assert_true(HashTable__put_unique(&me, i, 1234567890));
+        g_assert_true(HashTable__put(&me, i, 1234567890));
     }
 
     for (size_t i = 0; i < N; ++i) {

--- a/test/lib_test/lookup_test/meson.build
+++ b/test/lib_test/lookup_test/meson.build
@@ -1,3 +1,16 @@
+k_hash_table_test_exe = executable(
+    'k_hash_table_test_exe',
+    'k_hash_table_test.c',
+    include_directories: [
+        mytester_include,
+    ],
+    dependencies: [
+        common_dep,
+        glib_dep,
+        lookup_dep,
+    ],
+)
+
 lookup_test_exe = executable(
     'lookup_test_exe',
     'lookup_test.c',
@@ -39,6 +52,7 @@ evicting_lookup_test_exe = executable(
     ],
 )
 
+test('k_hash_table_test', k_hash_table_test_exe)
 test('lookup_test', lookup_test_exe)
 test('parallel_lookup_test', parallel_lookup_test_exe)
 test('evicting_lookup_test', evicting_lookup_test_exe)

--- a/test/lib_test/lookup_test/meson.build
+++ b/test/lib_test/lookup_test/meson.build
@@ -1,3 +1,16 @@
+boost_hash_table_test_exe = executable(
+    'boost_hash_table_test_exe',
+    'boost_hash_table_test.c',
+    include_directories: [
+        mytester_include,
+    ],
+    dependencies: [
+        common_dep,
+        glib_dep,
+        lookup_dep,
+    ],
+)
+
 k_hash_table_test_exe = executable(
     'k_hash_table_test_exe',
     'k_hash_table_test.c',
@@ -52,6 +65,7 @@ evicting_lookup_test_exe = executable(
     ],
 )
 
+test('boost_hash_table_test', boost_hash_table_test_exe)
 test('k_hash_table_test', k_hash_table_test_exe)
 test('lookup_test', lookup_test_exe)
 test('parallel_lookup_test', parallel_lookup_test_exe)

--- a/test/lib_test/lookup_test/parallel_lookup_test.c
+++ b/test/lib_test/lookup_test/parallel_lookup_test.c
@@ -34,7 +34,7 @@ single_thread_test(void)
     g_assert_true(ParallelHashTable__init(&me, 8));
 
     for (size_t i = 0; i < N; ++i) {
-        g_assert_true(ParallelHashTable__put_unique(&me, i, i));
+        g_assert_true(ParallelHashTable__put(&me, i, i));
     }
 
     for (size_t i = 0; i < N; ++i) {
@@ -43,7 +43,7 @@ single_thread_test(void)
     }
 
     for (size_t i = 0; i < N; ++i) {
-        g_assert_true(ParallelHashTable__put_unique(&me, i, 1234567890));
+        g_assert_true(ParallelHashTable__put(&me, i, 1234567890));
     }
 
     for (size_t i = 0; i < N; ++i) {
@@ -67,10 +67,9 @@ multithread_writer(void *args)
 {
     struct WorkerArgs *w = args;
     for (EntryType entry = w->start; entry < w->end; ++entry) {
-        g_assert_true(
-            ParallelHashTable__put_unique(w->hash_table,
-                                          entry,
-                                          w->entry_to_timestamp(entry)));
+        g_assert_true(ParallelHashTable__put(w->hash_table,
+                                             entry,
+                                             w->entry_to_timestamp(entry)));
     }
     return NULL;
 }

--- a/test/mrc_test/average_eviction_time_test.c
+++ b/test/mrc_test/average_eviction_time_test.c
@@ -7,7 +7,6 @@
 #include "logger/logger.h"
 #include "miss_rate_curve/miss_rate_curve.h"
 #include "olken/olken.h"
-#include "random/zipfian_random.h"
 #include "test/mytester.h"
 #include "trace/generator.h"
 #include "trace/trace.h"

--- a/test/mrc_test/average_eviction_time_test.c
+++ b/test/mrc_test/average_eviction_time_test.c
@@ -11,6 +11,7 @@
 #include "test/mytester.h"
 #include "trace/generator.h"
 #include "trace/trace.h"
+#include "unused/mark_unused.h"
 
 static bool
 access_same_key_five_times(void)

--- a/test/mrc_test/fixed_rate_shards_test.c
+++ b/test/mrc_test/fixed_rate_shards_test.c
@@ -44,6 +44,8 @@ access_same_key_five_times(void)
 
     Olken__destroy(&oracle);
     FixedRateShards__destroy(&me);
+    MissRateCurve__destroy(&oracle_mrc);
+    MissRateCurve__destroy(&mrc);
     return true;
 }
 
@@ -84,6 +86,8 @@ small_exact_trace_test(void)
 
     Olken__destroy(&oracle);
     FixedRateShards__destroy(&me);
+    MissRateCurve__destroy(&oracle_mrc);
+    MissRateCurve__destroy(&mrc);
     return true;
 }
 
@@ -120,6 +124,8 @@ long_accuracy_trace_test(void)
     ZipfianRandom__destroy(&zrng);
     Olken__destroy(&oracle);
     FixedRateShards__destroy(&me);
+    MissRateCurve__destroy(&oracle_mrc);
+    MissRateCurve__destroy(&mrc);
     return true;
 }
 
@@ -169,6 +175,8 @@ long_parda_matching_trace_test(void)
     ZipfianRandom__destroy(&zrng);
     PardaFixedRateShards__destroy(&oracle);
     FixedRateShards__destroy(&me);
+    MissRateCurve__destroy(&oracle_mrc);
+    MissRateCurve__destroy(&mrc);
     return true;
 }
 

--- a/test/mrc_test/fixed_size_shards_test.c
+++ b/test/mrc_test/fixed_size_shards_test.c
@@ -108,7 +108,7 @@ long_accuracy_trace_test(void)
         Olken__access_item(&oracle, entry);
         FixedSizeShards__access_item(&me, entry);
         // Verify the fixed size of this method
-        g_assert_cmpuint(HashTable__get_size(&me.olken.hash_table),
+        g_assert_cmpuint(Olken__get_cardinality(&me.olken),
                          <=,
                          me.sampler.pq.capacity);
         g_assert_cmpuint(me.olken.tree.cardinality, <=, me.sampler.pq.capacity);


### PR DESCRIPTION
Switch the Olken hash table to khash, which uses less memory and is supposedly faster.